### PR TITLE
Parent reference

### DIFF
--- a/Strike.lua
+++ b/Strike.lua
@@ -53,13 +53,6 @@ local function striking(collider1, collider2)
 			end
 		end
 	end
-	if from == 1 then
-		max_mtv:setCollider(collider1)
-		max_mtv:setCollided(collider2)
-	elseif from == 2 then
-		max_mtv:setCollider(collider2)
-		max_mtv:setCollided(collider1)
-	end
 	return max_mtv:mag() ~= 0 and from, max_mtv or false
 end
 

--- a/algs/SAT.lua
+++ b/algs/SAT.lua
@@ -25,7 +25,11 @@ local function project(shape1, shape2)
 		-- Test for bounding overlap
 		if not ( shape1_max_dot > shape2_min_dot and shape2_max_dot > shape1_min_dot ) then
 			-- Separating Axis, return
-			return false, MTV:fetch(dx, dy)
+            local mtv = MTV:fetch(dx, dy)
+            mtv:setColliderShape(shape1)
+            mtv:setEdgeIndex(edge_index)
+            mtv:setCollidedShape(shape2)
+			return false, mtv
 		else
 			-- Find the overlap (minimum difference of bounds), which is equal to the magnitude of the MTV
 			overlap = min(shape1_max_dot-shape2_min_dot, shape2_max_dot-shape1_min_dot)

--- a/colliders/Collider.lua
+++ b/colliders/Collider.lua
@@ -22,6 +22,7 @@ Collider.shapes = {}
 ---@param shape Shape
 function Collider:add(shape, ...)
     if not shape then return end
+    shape.parent = self
     push(self.shapes, shape)
     self:add(...)
 end

--- a/shapes/Shape.lua
+++ b/shapes/Shape.lua
@@ -5,9 +5,18 @@ local Object = Libs.classic
 ---@field public centroid Point
 ---@field public area number
 ---@field public radius number
+---@field public parent nil|Shape|Collider
 local Shape = Object:extend()
 
 Shape.type = 'shape'
+
+function Shape:getRoot()
+	local s = self
+	while s.parent do
+		s = s.parent
+	end
+	return s
+end
 
 ---@return number area
 function Shape:getArea()


### PR DESCRIPTION
Better codifies the parent-child relationship of Colliders & Shapes + Other Colliders. Allows the retrieval of more context for an MTV on demand, rather than having to set it in `striking`