### PR TITLE
Axis cache

### DIFF
--- a/algs/SAT.lua
+++ b/algs/SAT.lua
@@ -36,7 +36,7 @@ end
 
 -- SAT
 local function project(shape1, shape2)
-	local mtv = MTV:fetch(inf,inf)
+	local mtv = MTV(inf,inf)
 	-- Test cache
 	local v = acache:get({shape1, shape2})
 	if v then

--- a/algs/SAT.lua
+++ b/algs/SAT.lua
@@ -63,8 +63,7 @@ local function project(shape1, shape2)
 	-- Flip it?
 	local ccx, ccy = shape2.centroid.x - shape1.centroid.x, shape2.centroid.y - shape1.centroid.y
 	local s = sign( Vec.dot(mtv.x, mtv.y, ccx, ccy) )
-	mtv.x, mtv.y = Vec.mul(s, mtv.x, mtv.y)
-	mtv:new(mtv.x, mtv.y, shape1, shape2, false)
+	mtv:scale(s):setCollider(shape1):setCollided(shape2):setSeparating(false)
 	return mtv
 end
 

--- a/algs/SAT.lua
+++ b/algs/SAT.lua
@@ -63,7 +63,7 @@ local function project(shape1, shape2)
 	-- Flip it?
 	local ccx, ccy = shape2.centroid.x - shape1.centroid.x, shape2.centroid.y - shape1.centroid.y
 	local s = sign( Vec.dot(mtv.x, mtv.y, ccx, ccy) )
-	mtv:scale(s):setCollider(shape1):setCollided(shape2):setSeparating(false)
+	mtv:scale(s):setColliderShape(shape1):setCollidedShape(shape2):setSeparating(false)
 	return mtv
 end
 

--- a/algs/SAT.lua
+++ b/algs/SAT.lua
@@ -1,4 +1,5 @@
 local Vec = _Require_relative( ... , 'lib.DeWallua.vector-light', 1)
+local Cache = _Require_relative(..., 'classes.Cache',1)
 local MTV = _Require_relative(..., 'classes.MTV',1)
 local min = math.min
 local inf = math.huge
@@ -8,42 +9,62 @@ local function sign(number)
     return number > 0 and 1 or (number == 0 and 0 or -1)
 end
 
+-- Cache:
+local acache = Cache()
+
+local function test_axis(shape1, shape2, dx,dy, mtv)
+	local shape1_min_dot, shape1_max_dot = shape1:project(dx,dy)
+	local shape2_min_dot, shape2_max_dot = shape2:project(dx,dy)
+	-- We've now reduced it to ranges intersecting on a number line,
+	-- Test for bounding overlap
+	if not ( shape1_max_dot > shape2_min_dot and shape2_max_dot > shape1_min_dot ) then
+		-- Separating Axis, return
+		mtv:new(dx, dy, shape1, shape2, true)
+		-- Add to cache
+		acache:set({shape1, shape2}, mtv)
+	else
+		-- Find the overlap (minimum difference of bounds), which is equal to the magnitude of the MTV
+		local overlap = min(shape1_max_dot-shape2_min_dot, shape2_max_dot-shape1_min_dot)
+		if overlap*overlap < mtv:mag2() then
+			-- Set our MTV to the smol vector
+			mtv.x, mtv.y = Vec.mul(overlap, dx, dy)
+		end
+	end
+	return mtv
+end
+
+
 -- SAT
 local function project(shape1, shape2)
-	local minimum, mtv_dx, mtv_dy, edge_index = inf, 0, 0, 0
-	local overlap, dx, dy
-	local shape1_min_dot, shape1_max_dot, shape2_min_dot, shape2_max_dot
+	local mtv = MTV:fetch(inf,inf)
+	-- Test cache
+	local v = acache:get({shape1, shape2})
+	if v then
+		mtv = test_axis(shape1, shape2, v.x,v.y, mtv)
+		if mtv.separating then
+			return mtv
+		end
+	end
+	-- Cached axis failed :(
+	local dx, dy
+	mtv:new(inf,inf)
+
 	-- loop through shape1 geometry
 	for i, vec in shape1:vecs(shape2) do
 		-- get the normal
 		dx, dy = Vec.normalize( vec.x, vec.y )
 		dx, dy = dy, -dx
-		-- Project both shapes 1 and 2 onto this normal to get their shadows
-		shape1_min_dot, shape1_max_dot = shape1:project(dx, dy)
-		shape2_min_dot, shape2_max_dot = shape2:project(dx, dy)
-		-- We've now reduced it to ranges intersecting on a number line,
-		-- Test for bounding overlap
-		if not ( shape1_max_dot > shape2_min_dot and shape2_max_dot > shape1_min_dot ) then
-			-- Separating Axis, return
-            local mtv = MTV:fetch(dx, dy, shape1, shape2, true)
-            return mtv
-		else
-			-- Find the overlap (minimum difference of bounds), which is equal to the magnitude of the MTV
-			overlap = min(shape1_max_dot-shape2_min_dot, shape2_max_dot-shape1_min_dot)
-			if overlap < minimum then
-				-- Set our MTV to the smol vector
-				minimum = overlap
-				mtv_dx, mtv_dy = dx, dy
-				edge_index = i
-			end
+		mtv = test_axis(shape1,shape2,dx,dy,mtv)
+		if mtv.separating then
+			return mtv
 		end
 	end
+	-- Welp. We made it here. So they're colliding, I guess. Hope it's consensual :(
 	-- Flip it?
 	local ccx, ccy = shape2.centroid.x - shape1.centroid.x, shape2.centroid.y - shape1.centroid.y
-	local s = sign( Vec.dot(mtv_dx, mtv_dy, ccx, ccy) )
-	-- Welp. We made it here. So they're colliding, I guess. Hope it's consensual :(
-	local mx, my = Vec.mul(s*minimum, mtv_dx, mtv_dy)
-	local mtv = MTV:fetch(mx, my, shape1, shape2, false)
+	local s = sign( Vec.dot(mtv.x, mtv.y, ccx, ccy) )
+	mtv.x, mtv.y = Vec.mul(s, mtv.x, mtv.y)
+	mtv:new(mtv.x, mtv.y, shape1, shape2, false)
 	return mtv
 end
 

--- a/classes/Cache.lua
+++ b/classes/Cache.lua
@@ -1,0 +1,64 @@
+-- This Cache class steals cache_get/put from Kikito's memoize.lua
+-- https://github.com/kikito/memoize.lua
+--[[
+    Copyright (c) 2018 Enrique García Cota
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+]]
+
+local Object = Libs.classic
+
+---@class Cache
+---@field cache table tree structure of weak tables
+Cache = Object:extend()
+
+local function wt()
+	return setmetatable({}, {__mode = "v"})
+end
+
+---Initializes cache to new weak-table
+function Cache:new()
+    self.cache = wt()
+end
+
+---Set result for given params table
+---@param params table Array of keys
+---@param results table Value/Array of values
+function Cache:set(params, results)
+    local node = self.cache
+    for i = 1, #params do
+        local param = params[i]
+        node.children = node.children or wt()
+        node.children[param] = node.children[param] or wt()
+        node = node.children[param]
+    end
+    node.results = results
+end
+
+---Return value for given param table
+---@param params table Array of keys
+---@return any result Cached value
+function Cache:get(params)
+    local node = self.cache
+    for i = 1, #params do
+        node = node.children and node.children[params[i]]
+        if not node then return nil end
+    end
+    return node.results
+end
+
+return Cache

--- a/classes/MTV.lua
+++ b/classes/MTV.lua
@@ -42,30 +42,35 @@ end
 ---@param collider Collider
 function MTV:setCollider(collider)
 	self.collider = collider
+	return self
 end
 
 ---Set the mtv's reference *shape*
 ---@param shape Shape
 function MTV:setColliderShape(shape)
 	self.colliderShape = shape
+	return self
 end
 
 ---Get edge at index
 ---@param index number index of colliderShape's edge that generated mtv
 function MTV:setEdgeIndex(index)
 	self.edgeIndex = index
+	return self
 end
 
 ---Set mtv's hit collider
 ---@param collider Collider
 function MTV:setCollided(collider)
 	self.collided = collider
+	return self
 end
 
 ---Set mtv's hit collider's *shape*
 ---@param shape Shape
 function MTV:setCollidedShape(shape)
 	self.collidedShape = shape
+	return self
 end
 
 return MTV

--- a/classes/MTV.lua
+++ b/classes/MTV.lua
@@ -38,6 +38,11 @@ function MTV:mag2()
 	return Vec.len2(self.x, self.y)
 end
 
+function MTV:scale(s)
+	self.x, self.y = s*self.x, s*self.y
+	return self
+end
+
 ---Set the mtv's reference
 ---@param collider Collider
 function MTV:setCollider(collider)

--- a/classes/MTV.lua
+++ b/classes/MTV.lua
@@ -78,4 +78,12 @@ function MTV:setCollidedShape(shape)
 	return self
 end
 
+---Set separation flag to true/false
+---@param bool boolean
+---@return MTV self
+function MTV:setSeparating(bool)
+	self.separating = bool
+	return self
+end
+
 return MTV


### PR DESCRIPTION
For a pair of shapes, a valid separating axis can be assumed to be "still good" for a few frames. 
This PR adds a [memoize.lua](https://github.com/kikito/memoize.lua) style Cache object to `/classes` and changes `SAT` to use it internally. The Cache object uses weak tables, so it shouldn't max out memory.