### PR TITLE
Change return type of `Shape:getCentroid`

### DIFF
--- a/Strike.lua
+++ b/Strike.lua
@@ -101,11 +101,11 @@ end
 ---@param mtv MTV
 local function show_proj(mtv)
 	for _, shape in mtv.collided:ipairs() do
-		local c = shape.centroid
+		local cx, cy = shape:getCentroid()
 		local nmx, nmy = Vec.normalize(mtv.x, mtv.y)
 		local smin, smax = shape:project(nmx, nmy)
 		love.graphics.setColor(.5,.5,.1)
-	   	love.graphics.line(c.x+nmx*smin, c.y+nmy*smin, c.x+nmx*smax, c.y+nmy*smax)
+	   	love.graphics.line(cx + nmx*smin, cy + nmy*smin, cx + nmx*smax, cy + nmy*smax)
 		love.graphics.setColor(1,1,1)
     end
 end

--- a/algs/SAT.lua
+++ b/algs/SAT.lua
@@ -15,9 +15,9 @@ end
 ---@param shape2 Shape
 ---@return integer sign
 local function reference_frame(mtv, shape1, shape2)
-	local c1 = shape1:getCentroid()
-	local c2 = shape2:getCentroid()
-	local ccx, ccy = c2.x - c1.x, c2.y - c1.y
+	local c1x, c1y = shape1:getCentroid()
+	local c2x, c2y = shape2:getCentroid()
+	local ccx, ccy = c2x - c1x, c2y - c1y
 	return sign( Vec.dot(mtv.x, mtv.y, ccx, ccy) )
 end
 

--- a/colliders/Collider.lua
+++ b/colliders/Collider.lua
@@ -80,9 +80,10 @@ function Collider:calcCentroid()
     self.centroid.x, self.centroid.y = 0,0
     local area = 0
     for shape in self:elems() do
+        local sx, sy = shape:getCentroid()
         area = area + shape.area
-        self.centroid.x = self.centroid.x + shape.centroid.x * shape.area
-        self.centroid.y = self.centroid.y + shape.centroid.y * shape.area
+        self.centroid.x = self.centroid.x + sx * shape.area
+        self.centroid.y = self.centroid.y + sy * shape.area
     end
     self.centroid.x, self.centroid.y = self.centroid.x/area, self.centroid.y/area
     return self.centroid
@@ -95,9 +96,10 @@ function Collider:calcAreaCentroid()
     self.centroid.x, self.centroid.y = 0,0
     self.area = 0
     for shape in self:elems() do
+        local sx, sy = shape:getCentroid()
         self.area = self.area + shape.area
-        self.centroid.x = self.centroid.x + shape.centroid.x * shape.area
-        self.centroid.y = self.centroid.y + shape.centroid.y * shape.area
+        self.centroid.x = self.centroid.x + sx * shape.area
+        self.centroid.y = self.centroid.y + sy * shape.area
     end
     self.centroid.x, self.centroid.y = self.centroid.x/self.area, self.centroid.y/self.area
     return self.area, self.centroid
@@ -109,7 +111,8 @@ function Collider:calcRadius()
     self.radius = 0
     local cx,cy = self.centroid.x, self.centroid.y
     for shape in self:elems() do
-        local r = Vec.len(cx - shape.centroid.x, cy - shape.centroid.y) + shape.radius
+        local sx, sy = shape:getCentroid()
+        local r = Vec.len(cx - sx, cy - sy) + shape.radius
         self.radius = self.radius > r and self.radius or r
     end
     return self.radius
@@ -314,8 +317,9 @@ function Collider:draw(mode)
     for shape in self:elems() do
         if mode == 'rainbow' then love.graphics.setColor(love.math.random(), love.math.random(), love.math.random()) end
         shape:draw(mode)
-        love.graphics.points(shape.centroid.x, shape.centroid.y)
-        love.graphics.print(_,shape.centroid.x, shape.centroid.y)
+        local sx, sy = shape:getCentroid()
+        love.graphics.points(sx, sy)
+        love.graphics.print(_, sx, sy)
     end
 end
 

--- a/shapes/Circle.lua
+++ b/shapes/Circle.lua
@@ -44,33 +44,33 @@ end
 
 -- We can't actually iterate over circle geometry, but we can return a single edge
 -- from the circle centroid to closest point of test shape
-local function get_closest_point(shape, p)
+local function get_closest_point(shape, x,y)
     local dist, min_dist, min_p
     for i, v in ipairs(shape.vertices) do
-        dist = Vec.dist2(p.x,p.y, v.x,v.y)
+        dist = Vec.dist2(x,y, v.x,v.y)
         if not min_dist or dist < min_dist then
             min_dist = dist
             min_p = v
         end
     end
-    return min_p
+    return min_p.x, min_p.y
 end
 
 local function iter_edges(state)
     local endx, endy
 	state.i = state.i + 1
-    local c = state.self.centroid
+    local cx, cy = state.self:getCentroid()
     local shape = state.shape
-    local sc = shape.centroid
+    local sx, sy = shape:getCentroid()
 	if state.i <= 1 then
         if shape.name == 'circle' then
-            endx, endy = sc.x, sc.y
+            endx, endy = sx, sy
         else
-            local mp = get_closest_point(shape, c)
+            local mp = get_closest_point(shape, cx, cy)
             endx, endy = mp.x, mp.y
         end
-        local normx, normy = Vec.perpendicular(Vec.sub(endx,endy, c.x,c.y))
-        return state.i, {c.x,c.y, c.x+normx,c.y+normy}
+        local normx, normy = Vec.perpendicular(Vec.sub(endx,endy, cx,cy))
+        return state.i, {cx, cy, cx+normx, cy+normy}
     end
 end
 
@@ -82,17 +82,16 @@ end
 local function iter_vecs(state)
     local endx, endy
 	state.i = state.i + 1
-    local c = state.self.centroid
+    local cx, cy = state.self:getCentroid()
     local shape = state.shape
-    local sc = shape.centroid
+    local sx, sy = shape:getCentroid()
 	if state.i <= 1 then
         if shape.name == 'circle' then
-            endx, endy = sc.x, sc.y
+            endx, endy = sx, sy
         else
-            local mp = get_closest_point(shape, c)
-            endx, endy = mp.x, mp.y
+            endx, endy = get_closest_point(shape, cx, cy)
         end
-        local normx, normy = Vec.perpendicular(Vec.sub(endx,endy, c.x,c.y))
+        local normx, normy = Vec.perpendicular(Vec.sub(endx,endy, cx,cy))
         return state.i, {x = normx, y = normy}
     end
 end
@@ -118,12 +117,14 @@ end
 
 ---Rotate by specified radians
 ---@param angle number radians
----@param refx number reference x-coordinate
----@param refy number reference y-coordinate
+---@param x number reference x-coordinate
+---@param y number reference y-coordinate
 ---@return Circle self
-function Circle:rotate(angle, refx, refy)
+function Circle:rotate(angle, x, y)
+    x = x or 0
+    y = y or 0
     local c = self.centroid
-    c.x, c.y = Vec.add(refx, refy, Vec.rotate(angle, c.x-refx, c.y - refy))
+    c.x, c.y = Vec.add(x, y, Vec.rotate(angle, c.x-x, c.y - y))
 	return self
 end
 

--- a/shapes/Shape.lua
+++ b/shapes/Shape.lua
@@ -25,9 +25,10 @@ function Shape:getArea()
     return self.area
 end
 
----@return Point self.centroid
+---@return number x
+---@return number y
 function Shape:getCentroid()
-    return self.centroid
+    return self.centroid.x, self.centroid.y
 end
 
 ---@return number area, table centroid


### PR DESCRIPTION
To prep for adding transforms, the centroid needs to be accessed through `getCentroid` instead of indexing into it. `getCentroid` now returns `x,y` coordinates of the centroid instead of the table.