### PR TITLE
All Shapes now call their super constructors

### DIFF
--- a/shapes/Circle.lua
+++ b/shapes/Circle.lua
@@ -13,14 +13,14 @@ Circle.name = 'circle'
 ---@param y number y coordinate
 ---@param radius number
 ---@param angle number angle offset
----@return boolean
 function Circle:new(x, y, radius, angle)
 	if not ( radius ) then return false end
-	local x_offset = x or 0
-	local y_offset = y or 0
+    Circle.super.new(self)
+	x = x or 0
+	y = y or 0
 	-- Put everything into circle table and then return it
 	self.convex   = true                          -- boolean
-    self.centroid = {x = x_offset, y = y_offset}  -- {x, y} coordinate pair
+    self.centroid = {x = x, y = y}  -- {x, y} coordinate pair
     self.radius   = radius				        -- radius of circumscribed circle
     self.area     = pi*radius^2				    -- absolute/unsigned area of polygon
     self.angle    = angle or 0

--- a/shapes/ConvexPolygon.lua
+++ b/shapes/ConvexPolygon.lua
@@ -8,17 +8,6 @@ local VertexShape = _Require_relative(...,"VertexShape")
 ConvexPolygon = VertexShape:extend()
 ConvexPolygon.name = 'convex'
 
--- Recursive function that returns a list of {x=#,y=#} coordinates given a list of procedural, ccw coordinate pairs
-local function to_verts(vertices, x, y, ...)
-    if not (x and y) then return vertices end
-	vertices[#vertices + 1] = {x = x, y = y} -- , dx = 0, dy = 0}   -- set vertex
-	return to_verts(vertices, ...)
-end
-
-local function to_vertices(vertices, x, ...)
-	return type(x) == 'table'and to_verts(vertices, unpack(x)) or to_verts(vertices, x,...)
-end
-
 -- Test if 3 points are collinear (do they not make a triangle?)
 local function is_collinear(a, b, c)
 	return abs(Vec.det(a.x-c.x, a.y-c.y, b.x-c.x,b.y-c.y)) <= 1e-32
@@ -227,7 +216,7 @@ end
 ---@param x number
 ---@param y number
 function ConvexPolygon:new(x,y, ...)
-    self.vertices = to_vertices({}, x,y, ...)
+    ConvexPolygon.super.new(self, x,y, ...)
 	assert(#self.vertices >= 3, "Need at least 3 non collinear points to build polygon (got "..#self.vertices..")")
 	if not is_convex(self.vertices) then
 		assert(order_points_ccw(self.vertices), 'Points cannot be ordered into a convex shape')

--- a/shapes/ConvexPolygon.lua
+++ b/shapes/ConvexPolygon.lua
@@ -1,10 +1,10 @@
-local abs, min, max, atan2 	= math.abs, math.min, math.max, math.atan2
+local abs, max, atan2 	= math.abs, math.max, math.atan2
 local push = table.insert
 local tbl = Libs.tbl
 local Vec = _Require_relative(..., 'lib.DeWallua.vector-light',1)
 local VertexShape = _Require_relative(...,"VertexShape")
 
----@class ConvexPolygon : Shape
+---@class ConvexPolygon : VertexShape
 ConvexPolygon = VertexShape:extend()
 ConvexPolygon.name = 'convex'
 
@@ -231,144 +231,6 @@ function ConvexPolygon:new(x,y, ...)
 	self:calcRadius()
 end
 
-local function iter_edges(shape, i)
-	i = i + 1
-	local len, ix, iy = #shape.vertices, shape:getVertex(i)
-	if i <= len then
-		local j = i < len and i+1 or 1
-		local jx, jy = shape:getVertex(j)
-		return i, {ix, iy, jx, jy}
-	end
-end
-
----Edge Iterator
----@return function
----@return ConvexPolygon
----@return number
-function ConvexPolygon:ipairs()
-    return iter_edges, self, 0
-end
-
----comment
----@param shape ConvexPolygon
----@param i number
----@return integer
----@return table
-local function iter_vecs(shape, i)
-	i = i + 1
-	local len, ix, iy = #shape.vertices, shape:getVertex(i)
-	if i <= len then
-		local j = i < len and i+1 or 1
-		local jx, jy = shape:getVertex(j)
-		return i, {x = jx - ix, y = jy - iy}
-	end
-end
-
----Iterate over edge vectors
----@return function
----@return ConvexPolygon
----@return number
-function ConvexPolygon:vecs()
-    return iter_vecs, self, 0
-end
-
----Translate by displacement vector
----@param dx number
----@param dy number
----@return ConvexPolygon self
-function ConvexPolygon:translate(dx, dy)
-	-- Translate each vertex by dx, dy
-	local vertices = self.vertices
-    for i = 1, #vertices do
-        vertices[i].x = vertices[i].x + dx
-        vertices[i].y = vertices[i].y + dy
-    end
-	-- Translate centroid
-	self.centroid.x = self.centroid.x + dx
-	self.centroid.y = self.centroid.y + dy
-    return self
-end
-
----Rotate by specified radians
----@param angle number radians
----@param refx number reference x-coordinate
----@param refy number reference y-coordinate
----@return ConvexPolygon self
-function ConvexPolygon:rotate(angle, refx, refy)
-	-- Default to centroid as ref-point
-    refx = refx or self.centroid.x
-	refy = refy or self.centroid.y
-	-- Rotate each vertex about ref-point
-    for i = 1, #self.vertices do
-        local v = self.vertices[i]
-        v.x, v.y = Vec.add(refx, refy, Vec.rotate(angle, v.x-refx, v.y - refy))
-    end
-	self.centroid.x, self.centroid.y = Vec.add(refx, refy, Vec.rotate(angle, self.centroid.x-refx, self.centroid.y-refy))
-	self.angle = self.angle + angle
-	return self
-end
-
---- scale helper function
-local function scale_p(x,y, sf,rx,ry)
-	return Vec.add(rx, ry, Vec.mul(sf, x-rx, y - ry))
-end
-
----Scale polygon
----@param sf number scale factor
----@param refx number reference x-coordinate
----@param refy number reference y-coordinate
----@return ConvexPolygon self
-function ConvexPolygon:scale(sf, refx, refy)
-	-- Default to centroid as ref-point
-	local c = self.centroid
-    refx = refx or c.x
-	refy = refy or c.y
-	-- Push each vertex out from the ref point by scale-factor
-    for i = 1, #self.vertices do
-        local v = self.vertices[i]
-        v.x, v.y = scale_p(v.x,v.y, sf,refx,refy)
-    end
-	c.x, c.y = scale_p(c.x, c.y, sf, refx, refy)
-    -- Recalculate area, and radius
-    self.area = self.area * sf * sf
-    self.radius = self.radius * sf
-	return self
-end
-
----Project polygon along normalized vector
----@param nx number normalized x-component
----@param ny number normalized y-component
----@return number minimum, number maximumum smallest, largest projection
-function ConvexPolygon:project(nx,ny)
-	local vertices = self.vertices
-	local proj_x, proj_y
-	local p, min_dot, max_dot
-	-- Project each point onto vector <nx, ny>
-	proj_x, proj_y = self:getVertex(1)
-	-- Init our min/max dot products (Can't init to random value)
-	min_dot = Vec.dot(proj_x,proj_y, nx,ny)
-	max_dot = min_dot
-	-- Create new projection vectors, dot-prod them with the input vector, and return the min/max
-	for i = 2, #vertices do
-		proj_x, proj_y = self:getVertex(i)
-		p = Vec.dot(proj_x,proj_y, nx,ny)
-		if p < min_dot then min_dot = p elseif p > max_dot then max_dot = p end
-	end
-	return min_dot, max_dot
-end
-
----Get an edge by index
----@param i number
----@return table|false res edge of form {x1,y1, x2,y2} or false if index out of range
-function ConvexPolygon:getEdge(i)
-	if i > #self.vertices then return false end
-	local verts = self.vertices
-	local j = i < #verts and i+1 or 1
-	local p1x, p1y = self:getVertex(i)
-	local p2x, p2y = self:getVertex(j)
-	return {p1x, p1y, p2x, p2y}
-end
-
 --- Need this to test if a shape is completely inside
 ---@param point Point
 function ConvexPolygon:containsPoint(point)
@@ -389,47 +251,6 @@ function ConvexPolygon:containsPoint(point)
 		end
 	end
 	return winding ~= 0
-end
-
----Project each individual edge instead of using self:project like in Circle
----@param x number ray origin
----@param y number ray origin
----@param dx number normalized x component
----@param dy number normalized y component
----@return boolean hit
-function ConvexPolygon:rayIntersects(x,y, dx,dy)
-	dx, dy = Vec.perpendicular(dx,dy)
-    local d = Vec.dot(x,y, dx,dy)
-	for i, edge in self:ipairs() do
-		local e1 = Vec.dot(edge[1],edge[2], dx,dy)
-		local e2 = Vec.dot(edge[3],edge[4], dx,dy)
-		if (e1-d) * (e2-d) <= 0 then return true end
-	end
-	return false
-end
-
--- https://stackoverflow.com/a/32146853/12135804
----Return all intersections as distances along ray
----@param x number ray origin
----@param y number ray origin
----@param dx number normalized x component
----@param dy number normalized y component
----@param ts table
----@return table | nil intersections
-function ConvexPolygon:rayIntersections(x,y, dx,dy, ts)
-	local v1x, v1y, v2x, v2y
-	local nx, ny = -dy, dx
-	ts = ts or {}
-	for i, edge in self:ipairs() do
-		v1x, v1y = Vec.sub(x, y, edge[1], edge[2])
-		v2x, v2y = Vec.sub(edge[3], edge[4], edge[1], edge[2])
-		local dot = Vec.dot(v2x, v2y, nx, ny)
-		if abs(dot) < 0.0001 then break end
-		local t1 = Vec.det(v2x,v2y, v1x,v1y) / dot
-		local t2 = Vec.dot(v1x,v1y, nx,ny) / dot
-		if t1 >= 0 and (t2 >= 0 and t2 <= 1) then push(ts, t1) end
-	end
-	return #ts > 0 and ts or nil
 end
 
 ConvexPolygon._get_verts = ConvexPolygon.unpack
@@ -503,44 +324,6 @@ local function merge_convex_incident(poly1, poly2)
 end
 
 ConvexPolygon.merge = merge_convex_incident
-
----Contact Functions
-function ConvexPolygon:getSupport(nx,ny)
-    local maxd, index = -math.huge , 1
-    for i = 1, #self.vertices do
-		local px,py = self:getVertex(i)
-        local projection = Vec.dot(px,py, nx,ny)
-        if projection > maxd then
-            maxd = projection
-            index = i
-        end
-    end
-    return index
-end
-
----Get the edge involved in a collision
----@param nx number normalized x dir
----@param ny number normalized y dir
----@return table Max-Point
----@return table Edge
-function ConvexPolygon:getFeature(nx,ny)
-    local verts = self.vertices
-    -- get farthest point in direction of normal
-    local index = self:getSupport(nx,ny)
-    -- test adjacent points to find edge most perpendicular to normal
-    local vx, vy = self:getVertex(index)
-    local i0 = index - 1 >= 1 and index - 1 or #verts
-    local i1 = index + 1 <= #verts and index + 1 or 1
-    local v0x, v0y = self:getVertex(i0)
-    local v1x, v1y = self:getVertex(i1)
-    local gx,gy = Vec.normalize( Vec.sub(vx,vy, v0x,v0y) )
-    local hx,hy = Vec.normalize( Vec.sub(vx,vy, v1x,v1y) )
-    if math.abs(Vec.dot(gx,gy, nx,ny)) <= math.abs(Vec.dot(hx,hy, nx,ny)) then
-        return {x=vx,y=vy}, {{x=v0x,y=v0y}, {x=vx,y=vy}}
-    else
-        return {x=vx,y=vy}, {{x=vx,y=vy}, {x=v1x,y=v1y}}
-    end
-end
 
 if love and love.graphics then
 	---Draw polygon w/ LOVE

--- a/shapes/Edge.lua
+++ b/shapes/Edge.lua
@@ -41,10 +41,7 @@ end
 ---@param y2 number y coordinate of second point
 function Edge:new(x1,y1, x2,y2)
 
-	self.vertices = {
-		{x = x1, y = y1},
-		{x = x2, y = y2}
-	}
+	Edge.super.new(self, x1,y1, x2,y2)
 
 	self.centroid = {
 		x = (x1 + x2) / 2,

--- a/shapes/Ellipse.lua
+++ b/shapes/Ellipse.lua
@@ -16,43 +16,34 @@ Ellipse.name = 'ellipse'
 ---@param angle number radian offset
 function Ellipse:new(x, y, a, b, n, angle)
 	if not ( a or b ) then return false end -- We need both to make an ellipse!
-	-- Default to a ratio of major/minor axes = # of n per quadrant - multiply by 4 to get total n
-	local segs = n or max( floor(a/b)*4, 8)
-	-- Set ellipse coords
-	local x_offset 	= x or 0
-	local y_offset 	= y or 0
-	-- Set angle offset
+	x = x or 0
+	y = y or 0
 	angle = angle or 0
+	n = n or max(8, floor(a/b)*4) -- a/b = n per quadrant -> multiply by 4 to get total n
 
 	-- Init vertices list
 	local vertices = {}
 
 	-- Init delta-angle between vertices lying on ellipse hull
-	local d_rads = 2*pi / segs
+	local d_rads = 2*pi / n
 	-- For # of segs, compute vertex coordinates using
 	-- parametric eqns for an ellipse:
 	-- 		x = a * cos(theta)
 	-- 		y = b * sin(theta)
 	-- where a is the major axis and b is the minor axis
-	local a_offset = angle - d_rads
-	for i = 1, segs do
+	local a_offset = d_rads
+	for i = 1, n do
 		-- Increment our angle offset
 		a_offset = a_offset + d_rads
 		-- Add to vertices list
-		vertices[i] = {
-			x = x_offset + a * cos(a_offset),
-			y = y_offset + b * sin(a_offset)
-		}
+		table.insert(vertices, x + a * cos(a_offset))
+		table.insert(vertices, y + b * sin(a_offset))
 	end
-	-- Put everything into poly table and then return it
-    self.a, self.b  = a, b
-    self.n   		= n
-	self.vertices   = vertices			            -- list of {x,y} coords
-	self.convex     = true   					    -- boolean
-	self.centroid   = {x = x_offset, y = y_offset}	-- {x, y} coordinate pair
-	self.radius		= a							    -- radius of circumscribed circle
-	self.area		= pi*a*b						-- absolute/unsigned area of approx ellipse
-    self.angle      = angle
+
+	-- Set ellipse vars
+    self.a, self.b, self.n = a, b, n
+	Ellipse.super.new(self, vertices)
+	self:rotate(angle) -- set angle here because convex constructor defaults to 0
 end
 
 ---Return ctor args

--- a/shapes/Rectangle.lua
+++ b/shapes/Rectangle.lua
@@ -6,27 +6,24 @@ Rect = Polygon:extend()
 
 Rect.name = 'rect'
 
----Rect cotr
+---Rect ctor
 ---@param x number x position (center)
 ---@param y number y position (center)
 ---@param dx number width
----@param dy number height
----@param angle number radian offset
+---@param dy ?number height defaults to dx
+---@param angle ?number radian offset defaults to 0
 function Rect:new(x, y, dx, dy, angle)
-	if not ( dx and dy ) then return false end
-	local x_offset, y_offset = x or 0, y or 0
+	assert(dx, 'Rectangle constructor missing width/height')
+	dy = dy or dx
     self.dx, self.dy = dx, dy
 	self.angle = angle or 0
 	local hx, hy = dx/2, dy/2 -- halfsize
-	self.vertices = {
-		{x = x_offset - hx, y = y_offset - hy},
-		{x = x_offset + hx, y = y_offset - hy},
-		{x = x_offset + hx, y = y_offset + hy},
-		{x = x_offset - hx, y = y_offset + hy}
-	}
-	self.centroid  	= {x = x_offset, y = y_offset}
-	self.area 		= dx*dy
-	self.radius		= Vec.len(hx, hy)
+	Rect.super.new(self,
+		x - hx, y - hy,
+		x + hx, y - hy,
+		x + hx, y + hy,
+		x - hx, y + hy
+	)
 	self:rotate(self.angle)
 end
 

--- a/shapes/RegularPolygon.lua
+++ b/shapes/RegularPolygon.lua
@@ -5,6 +5,8 @@ local pi, cos, sin, tan = math.pi, math.cos, math.sin, math.tan
 ---@class RegularPolygon : ConvexPolygon
 local RegularPolygon = Polygon:extend()
 
+RegularPolygon.name = 'RegularPolygon'
+
 ---Calculate area using regular area formula
 ---@return number area
 function RegularPolygon:calcArea()
@@ -22,25 +24,22 @@ end
 function RegularPolygon:new(x, y, n, radius, angle)
     -- Initialize our polygon's origin and rotation
     n = n or 3
-    self.angle = angle or 0
-    self.area = 0
-    -- Initalize our dummy point vars to put into the vertices list
-    local vertices = {}
+    angle = angle or 0
 
     -- Calculate the points
-    for i = n, 1, -1 do -- i = 1, n calculates vertices in clockwise order, so go backwards
-        local vx = ( sin( i / n * 2 * pi - self.angle) * radius) + x
-        local vy = ( cos( i / n * 2 * pi - self.angle) * radius) + y
-        vertices[#vertices+1] = {x = vx, y = vy}
+    local vertices = {}
+
+    for i = 1, n do
+        local vx = ( sin(-i / n * 2 * pi) * radius) + x
+        local vy = ( cos(-i / n * 2 * pi) * radius) + y
+        table.insert(vertices, vx)
+        table.insert(vertices, vy)
     end
 
     -- Set fields
     self.n, self.radius = n, radius
-    self.vertices 		= vertices     	    -- list of {x,y} coords
-    self.convex      	= true      		-- boolean
-    self.centroid       = {x = x, y = y}	-- {x, y} coordinate pair
-    -- Calculate the area of our polygon.
-    self:calcArea()
+    RegularPolygon.super.new(self, vertices)
+    self:rotate(angle)
 end
 
 ---Return ctor args

--- a/shapes/VertexShape.lua
+++ b/shapes/VertexShape.lua
@@ -2,6 +2,27 @@ local Shape = _Require_relative(..., "Shape")
 
 local VertexShape = Shape:extend()
 
+-- Recursive function that returns a list of {x=#,y=#} coordinates given a list of procedural, ccw coordinate pairs
+local function to_verts(vertices, x, y, ...)
+    if not (x and y) then return vertices end
+	vertices[#vertices + 1] = {x = x, y = y} -- , dx = 0, dy = 0}   -- set vertex
+	return to_verts(vertices, ...)
+end
+
+local function to_vertices(x, ...)
+	return type(x) == 'table'and to_verts({}, unpack(x)) or to_verts({}, x,...)
+end
+
+-- Create new Polygon object
+---@vararg number x,y tuples
+---@param x number
+---@param y number
+function VertexShape:new(x,y, ...)
+    VertexShape.super.new(self)
+	self.centroid = {x=0, y=0}
+	self.vertices = to_vertices(x,y, ...)
+end
+
 ---Get a vertex by its offset
 ---@param i number
 ---@return number|false v.x or false if beyond range

--- a/shapes/VertexShape.lua
+++ b/shapes/VertexShape.lua
@@ -1,5 +1,11 @@
 local Shape = _Require_relative(..., "Shape")
+local Vec = _Require_relative(..., 'lib.DeWallua.vector-light',1)
+local abs = math.abs
+local push = table.insert
 
+---@class VertexShape : Shape
+---@field private centroid table<string, number>
+---@field private vertices table<number, table<string, number>>
 local VertexShape = Shape:extend()
 
 -- Recursive function that returns a list of {x=#,y=#} coordinates given a list of procedural, ccw coordinate pairs
@@ -31,6 +37,223 @@ function VertexShape:getVertex(i)
 	if i > #self.vertices then return false, false end
 	local v = self.vertices[i]
 	return v.x, v.y
+end
+
+---Get an edge by index
+---@param i number
+---@return table|false res edge of form {x1,y1, x2,y2} or false if index out of range
+function VertexShape:getEdge(i)
+	if i > #self.vertices then return false end
+	local verts = self.vertices
+	local j = i < #verts and i+1 or 1
+	local p1x, p1y = self:getVertex(i)
+	local p2x, p2y = self:getVertex(j)
+	return {p1x, p1y, p2x, p2y}
+end
+
+---Project polygon along normalized vector
+---@param nx number normalized x-component
+---@param ny number normalized y-component
+---@return number minimum, number maximumum smallest, largest projection
+function VertexShape:project(nx,ny)
+	local vertices = self.vertices
+	local proj_x, proj_y
+	local p, min_dot, max_dot
+	-- Project each point onto vector <nx, ny>
+	proj_x, proj_y = self:getVertex(1)
+	-- Init our min/max dot products (Can't init to random value)
+	min_dot = Vec.dot(proj_x,proj_y, nx,ny)
+	max_dot = min_dot
+	-- Create new projection vectors, dot-prod them with the input vector, and return the min/max
+	for i = 2, #vertices do
+		proj_x, proj_y = self:getVertex(i)
+		p = Vec.dot(proj_x,proj_y, nx,ny)
+		if p < min_dot then min_dot = p elseif p > max_dot then max_dot = p end
+	end
+	return min_dot, max_dot
+end
+
+---Translate by displacement vector
+---@param dx number
+---@param dy number
+---@return VertexShape self
+function VertexShape:translate(dx, dy)
+	-- Translate each vertex by dx, dy
+	local vertices = self.vertices
+    for i = 1, #vertices do
+        vertices[i].x = vertices[i].x + dx
+        vertices[i].y = vertices[i].y + dy
+    end
+	-- Translate centroid
+	self.centroid.x = self.centroid.x + dx
+	self.centroid.y = self.centroid.y + dy
+    return self
+end
+
+---Rotate by specified radians
+---@param angle number radians
+---@param refx number reference x-coordinate
+---@param refy number reference y-coordinate
+---@return VertexShape self
+function VertexShape:rotate(angle, refx, refy)
+	-- Default to centroid as ref-point
+    refx = refx or self.centroid.x
+	refy = refy or self.centroid.y
+	-- Rotate each vertex about ref-point
+    for i = 1, #self.vertices do
+        local v = self.vertices[i]
+        v.x, v.y = Vec.add(refx, refy, Vec.rotate(angle, v.x-refx, v.y - refy))
+    end
+	self.centroid.x, self.centroid.y = Vec.add(refx, refy, Vec.rotate(angle, self.centroid.x-refx, self.centroid.y-refy))
+	self.angle = self.angle + angle
+	return self
+end
+
+--- scale helper function
+local function scale_p(x,y, sf,rx,ry)
+	return Vec.add(rx, ry, Vec.mul(sf, x-rx, y - ry))
+end
+
+---Scale polygon
+---@param sf number scale factor
+---@param refx number reference x-coordinate
+---@param refy number reference y-coordinate
+---@return VertexShape self
+function VertexShape:scale(sf, refx, refy)
+	-- Default to centroid as ref-point
+	local c = self.centroid
+    refx = refx or c.x
+	refy = refy or c.y
+	-- Push each vertex out from the ref point by scale-factor
+    for i = 1, #self.vertices do
+        local v = self.vertices[i]
+        v.x, v.y = scale_p(v.x,v.y, sf,refx,refy)
+    end
+	c.x, c.y = scale_p(c.x, c.y, sf, refx, refy)
+    -- Recalculate area, and radius
+    self.area = self.area * sf * sf
+    self.radius = self.radius * sf
+	return self
+end
+
+local function iter_edges(shape, i)
+	i = i + 1
+	local len, ix, iy = #shape.vertices, shape:getVertex(i)
+	if i <= len then
+		local j = i < len and i+1 or 1
+		local jx, jy = shape:getVertex(j)
+		return i, {ix, iy, jx, jy}
+	end
+end
+
+---Edge Iterator
+---@return function
+---@return VertexShape
+---@return number
+function VertexShape:ipairs()
+    return iter_edges, self, 0
+end
+
+---Iterate through vectors that make up edges
+---@param shape VertexShape
+---@param i number
+---@return integer
+---@return table
+local function iter_vecs(shape, i)
+	i = i + 1
+	local len, ix, iy = #shape.vertices, shape:getVertex(i)
+	if i <= len then
+		local j = i < len and i+1 or 1
+		local jx, jy = shape:getVertex(j)
+		return i, {x = jx - ix, y = jy - iy}
+	end
+end
+
+---Iterate over edge vectors
+---@return function
+---@return VertexShape
+---@return number
+function VertexShape:vecs()
+    return iter_vecs, self, 0
+end
+
+---Project each individual edge instead of using self:project like in Circle
+---@param x number ray origin
+---@param y number ray origin
+---@param dx number normalized x component
+---@param dy number normalized y component
+---@return boolean hit
+function VertexShape:rayIntersects(x,y, dx,dy)
+	dx, dy = Vec.perpendicular(dx,dy)
+    local d = Vec.dot(x,y, dx,dy)
+	for i, edge in self:ipairs() do
+		local e1 = Vec.dot(edge[1],edge[2], dx,dy)
+		local e2 = Vec.dot(edge[3],edge[4], dx,dy)
+		if (e1-d) * (e2-d) <= 0 then return true end
+	end
+	return false
+end
+
+-- https://stackoverflow.com/a/32146853/12135804
+---Return all intersections as distances along ray
+---@param x number ray origin
+---@param y number ray origin
+---@param dx number normalized x component
+---@param dy number normalized y component
+---@param ts table
+---@return table | nil intersections
+function VertexShape:rayIntersections(x,y, dx,dy, ts)
+	local v1x, v1y, v2x, v2y
+	local nx, ny = -dy, dx
+	ts = ts or {}
+	for i, edge in self:ipairs() do
+		v1x, v1y = Vec.sub(x, y, edge[1], edge[2])
+		v2x, v2y = Vec.sub(edge[3], edge[4], edge[1], edge[2])
+		local dot = Vec.dot(v2x, v2y, nx, ny)
+		if abs(dot) < 0.0001 then break end
+		local t1 = Vec.det(v2x,v2y, v1x,v1y) / dot
+		local t2 = Vec.dot(v1x,v1y, nx,ny) / dot
+		if t1 >= 0 and (t2 >= 0 and t2 <= 1) then push(ts, t1) end
+	end
+	return #ts > 0 and ts or nil
+end
+
+---Contact Functions
+function VertexShape:getSupport(nx,ny)
+    local maxd, index = -math.huge , 1
+    for i = 1, #self.vertices do
+		local px,py = self:getVertex(i)
+        local projection = Vec.dot(px,py, nx,ny)
+        if projection > maxd then
+            maxd = projection
+            index = i
+        end
+    end
+    return index
+end
+
+---Get the edge involved in a collision
+---@param nx number normalized x dir
+---@param ny number normalized y dir
+---@return table Max-Point
+---@return table Edge
+function VertexShape:getFeature(nx,ny)
+    local verts = self.vertices
+    -- get farthest point in direction of normal
+    local index = self:getSupport(nx,ny)
+    -- test adjacent points to find edge most perpendicular to normal
+    local vx, vy = self:getVertex(index)
+    local i0 = index - 1 >= 1 and index - 1 or #verts
+    local i1 = index + 1 <= #verts and index + 1 or 1
+    local v0x, v0y = self:getVertex(i0)
+    local v1x, v1y = self:getVertex(i1)
+    local gx,gy = Vec.normalize( Vec.sub(vx,vy, v0x,v0y) )
+    local hx,hy = Vec.normalize( Vec.sub(vx,vy, v1x,v1y) )
+    if math.abs(Vec.dot(gx,gy, nx,ny)) <= math.abs(Vec.dot(hx,hy, nx,ny)) then
+        return {x=vx,y=vy}, {{x=v0x,y=v0y}, {x=vx,y=vy}}
+    else
+        return {x=vx,y=vy}, {{x=vx,y=vy}, {x=v1x,y=v1y}}
+    end
 end
 
 return VertexShape


### PR DESCRIPTION
This is to facilitate hiding the Transform object from the end user

Besides the constructor changes, all of the vertex methods that the `Edge` shape needed to access still resided in `ConvexPolygon` - those have (mostly) been moved to `VertexShape`