### PR TITLE
Move `calc` methods into VertexShape

### DIFF
--- a/shapes/Edge.lua
+++ b/shapes/Edge.lua
@@ -44,18 +44,9 @@ end
 ---@param x2 number x coordinate of second point
 ---@param y2 number y coordinate of second point
 function Edge:new(x1,y1, x2,y2)
-
 	Edge.super.new(self, x1,y1, x2,y2)
-
-	self.centroid = {
-		x = (x1 + x2) / 2,
-		y = (y1 + y2) / 2
-	}
-	self.radius = 0.5 * Vec.len(Vec.sub(x1,y1, x2,y2))
-	self.area = 1
 	self.norm = 0
 	self.angle = 0
-	self:calcAreaCentroid()
 end
 
 -- Only iterate once


### PR DESCRIPTION
Since `VertexShape` handles constructing the vertices list, it should also be responsible for calculating the area + centroid of those vertices. This works out since `Edge` already has its own `calc` methods that override `VertexShape`'s, so no worries about wonky numbers.

Along with moving the methods, the `centroid`, `area`, and `radius` property initialization has been moved to `VertexShape:new`, which calls `calcArea/Centroid/Radius`. The `Edge` and `ConvexPolygon` constructors are now solely focused on handling their own stuff.