### PR TITLE
Transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ shape:unpack()		-- Returns the args the shape was constructed with
 ```
 #### More specific query methods:
 ```lua
+shape:getEdge(i)
+```
+Given an index, returns the corresponding numbered edge. Returns `nil` if OOB
+```lua
 shape:project(nx, ny)
 ```
 Given two normalized vector components, returns the minimum and maximum values of the shape's projection onto the vector
-```lua
-shape:getEdge(i)
-```
-Given an index, returns the corresponding numbered edge. Returns `false` if OOB
 ```lua
 shape:containsPoint(point)
 ```

--- a/README.md
+++ b/README.md
@@ -266,34 +266,6 @@ MTV:setCollidedShape(shape)
 ```
 The one practical instance method of interest might be `MTV:mag()/mag2` - it returns the magnitude/magnitude-squared of the separating vector.
 
-### Object Pooling
-The `MTV` object implements the `Pool` mixin in [`classes/Pool.lua`](https://github.com/Aweptimum/Strike/blob/main/classes/Pool.lua). The following instance methods can be used to interact with the pool:
-```lua
-MTV:fetch(dx, dy, collider, collided)
-MTV:stow()
-```
-`fetch()` sets a previously initialized MTV to the given arguments and returns it from the pool. Its arguments are identical to the `MTV()` constructor as it uses `:new` to init the object
-`stow()` inserts the MTV instance into the object pool
-There is a default limit of 128 for any pool. The MTV pool size can be changed using Strike's `S.etPoolSize(size)` method or requiring the `MTV` object and calling `MTV:setPoolSize(size)`. Multiples of 2 are best because of lua-hash-table-resizing-stuff. The size can be acquired via `S.eePoolSize()/MTV:getPoolSize()`
-
-### Implementing Pooling
-If you both want to embrace `classic` in your own project and pool an ubiquitous object in your code, here's an example:
-```lua
-Object = Libs.classic
-Pool = require 'module-path.Strike.classes.Pool`
-
-local myObject = Object:extend():implement(Pool)
-```
-Your `myObject` object now has access to these methods and fields:
-```lua
-Pool.pool               -- Class's object pool
-Pool.size               -- Pool size limit
-Pool:getPoolSize()      -- Get the size of the object pool
-Pool:setPoolSize(size)  -- Set size of object pool (returns self)
-Pool:fetch( ... )       -- Fetch a pooled instance and init to given args (should match class constructor)
-Pool:stow( obj, ... )   -- Stow variable # of instances in Class pool
-```
-
 ## Collision
 ### Broad Phase
 Has both circle-circle and aabb-aabb intersection test functions - `S.ircle(collider1, collider2)` and `S.aabb(collider1, collider2)` respectively. Both return true on interesction, else false.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ shape:getEdge(i)
 ```
 Given an index, returns the corresponding numbered edge. Returns `nil` if OOB
 ```lua
+shape:getVertex(i)
+```
+Given an index, returns the corresponding numbered edge. Returns `nil` if OOB
+```lua
 shape:project(nx, ny)
 ```
 Given two normalized vector components, returns the minimum and maximum values of the shape's projection onto the vector

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ shape:scale(sf, refx, refy)	  -- scales by factor `sf` with respect to a referen
 ```
 
 ### Querying Shapes
+Under the hood, Strike's `Shape` class uses a Transform object, so directly accessing coordinates won't give expected values. Relevant getters return transformed coordinates, such as `getVertex`, so definitely use them.
+
 ```lua
 shape:getArea()		-- Returns the area of the shape
 shape:getCentroid()	-- Returns the centroid of the shape as a table {x = x, y = y}

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ collider:consolidate() 		-- will merge incident convex polygons together, makes 
 ```
 
 ### Collider Iterating
+There's the expensive `:ipairs()` method which uses a coroutine
 ```lua
 for parent_collider, shape, shape_index in collider:ipairs() do
 	-- stuff
@@ -189,6 +190,13 @@ end
 `Collider:ipairs()` is a flattened-list iterator that will return *all* Shapes, nested or not, contained within the 'root' Collider it's called from.
 `parent_collider` is the collider that contains `shape`, and `shape_index` is the index of `shape` within `parent_collider.shapes`.\
 If you wanted to remove a shape from a Collider that met some condition, calling `parent_collider:remove( shape_index )` would do it.
+
+And the cheaper `:elems()` method that returns only leaf nodes and does not use a coroutine
+```lua
+for shape in collider:elems() do
+    -- stuff
+end
+```
 
 ## Ray Intersection
 There are two ray intersection functions: `rayIntersects` and `rayIntersections`. Both have the same arguments: a ray origin and a normalized vector. The current implementation also assumes infinite length. They are defined both at the `Shapes` level and at the `Collider` level.

--- a/Strike.lua
+++ b/Strike.lua
@@ -73,10 +73,17 @@ end
 ---Draw an mtv w/ LOVE
 ---@param mtv MTV
 local function show_mtv(mtv)
-	local c = mtv.collider.centroid
+	if mtv.separating then
+		return
+	end
+	local cx, cy = mtv.colliderShape:getCentroid()
+	local ox, oy = mtv.collidedShape:getCentroid()
 	local edge = mtv.colliderShape:getEdge(mtv.edgeIndex)
+	local ex, ey =  (edge[1] + edge[3])/2, (edge[2] + edge[4])/2
+	love.graphics.setColor(.5,.5,1)
+	love.graphics.line(cx, cy, ex+mtv.x, ey+mtv.y)
 	love.graphics.setColor(1,.5,.5)
-	love.graphics.line(c.x, c.y, c.x+mtv.x, c.y+mtv.y)
+	love.graphics.line(cx, cy, ox, oy)
 	love.graphics.setColor(1,0,.5)
 	love.graphics.line(unpack(edge))
 	love.graphics.setColor(1,1,1)

--- a/Strike.lua
+++ b/Strike.lua
@@ -101,11 +101,11 @@ end
 ---@param mtv MTV
 local function show_proj(mtv)
 	for _, shape in mtv.collided:ipairs() do
-		local c = shape.centroid
+		local cx, cy = shape:getCentroid()
 		local nmx, nmy = Vec.normalize(mtv.x, mtv.y)
 		local smin, smax = shape:project(nmx, nmy)
 		love.graphics.setColor(.5,.5,.1)
-	   	love.graphics.line(c.x+nmx*smin, c.y+nmy*smin, c.x+nmx*smax, c.y+nmy*smax)
+	   	love.graphics.line(cx + nmx*smin, cy + nmy*smin, cx + nmx*smax, cy + nmy*smax)
 		love.graphics.setColor(1,1,1)
     end
 end

--- a/algs/SAT.lua
+++ b/algs/SAT.lua
@@ -67,6 +67,7 @@ local function project(shape1, shape2)
 		dx, dy = Vec.normalize( vec.x, vec.y )
 		dx, dy = dy, -dx
 		mtv = test_axis(shape1,shape2,dx,dy,mtv)
+		mtv:setEdgeIndex(i)
 		if mtv.separating then
 			return mtv
 		end

--- a/algs/SAT.lua
+++ b/algs/SAT.lua
@@ -9,6 +9,18 @@ local function sign(number)
     return number > 0 and 1 or (number == 0 and 0 or -1)
 end
 
+---Calculate if the mtv is along or against the reference frame
+---@param mtv MTV
+---@param shape1 Shape
+---@param shape2 Shape
+---@return integer sign
+local function reference_frame(mtv, shape1, shape2)
+	local c1 = shape1:getCentroid()
+	local c2 = shape2:getCentroid()
+	local ccx, ccy = c2.x - c1.x, c2.y - c1.y
+	return sign( Vec.dot(mtv.x, mtv.y, ccx, ccy) )
+end
+
 -- Cache:
 local acache = Cache()
 
@@ -61,8 +73,7 @@ local function project(shape1, shape2)
 	end
 	-- Welp. We made it here. So they're colliding, I guess. Hope it's consensual :(
 	-- Flip it?
-	local ccx, ccy = shape2.centroid.x - shape1.centroid.x, shape2.centroid.y - shape1.centroid.y
-	local s = sign( Vec.dot(mtv.x, mtv.y, ccx, ccy) )
+	local s = reference_frame(mtv, shape1, shape2)
 	mtv:scale(s):setColliderShape(shape1):setCollidedShape(shape2):setSeparating(false)
 	return mtv
 end

--- a/algs/SAT.lua
+++ b/algs/SAT.lua
@@ -15,9 +15,9 @@ end
 ---@param shape2 Shape
 ---@return integer sign
 local function reference_frame(mtv, shape1, shape2)
-	local c1 = shape1:getCentroid()
-	local c2 = shape2:getCentroid()
-	local ccx, ccy = c2.x - c1.x, c2.y - c1.y
+	local c1x, c1y = shape1:getCentroid()
+	local c2x, c2y = shape2:getCentroid()
+	local ccx, ccy = c2x - c1x, c2y - c1y
 	return sign( Vec.dot(mtv.x, mtv.y, ccx, ccy) )
 end
 

--- a/classes/MTV.lua
+++ b/classes/MTV.lua
@@ -23,7 +23,7 @@ function MTV:new(dx, dy, rshape, dshape, separating)
 	self.colliderShape = rshape
 	self.collidedShape = dshape
 	self.separating = separating or not true
-	self.edgeIndex = 0
+	self.edgeIndex = 1
 end
 
 ---Get MTV magnitude

--- a/classes/Transform.lua
+++ b/classes/Transform.lua
@@ -1,0 +1,200 @@
+local Object = Libs.classic
+local cos, sin = math.cos, math.sin
+---@type Pool
+--local Pool = _Require_relative( ..., 'Pool')
+
+---@class Transform : Object, Pool
+---@field x number
+---@field y number
+---@field cosa number cos term of a 2x2 rotation matrix
+---@field sina number sin term of a 2x2 rotation matrix
+---@field s number scale factor
+local Transform = Object:extend()--:implement(Pool)
+
+function Transform:new(x, y, ca, sa, s)
+    self.x = x or 0
+    self.y = y or 0
+    self.cosa = ca or 1
+    self.sina = sa or 0
+    self.s = s or 1
+end
+
+function Transform.fromAngle(x, y, a, s)
+    local cosa = a and cos(a) or 1
+    local sina = a and sin(a) or 0
+    return Transform(x, y, cosa, sina, s)
+end
+
+---Return the cos and sin components of the angle
+---@return number cosa
+---@return number sina
+function Transform:getRotation()
+    return self.cosa, self.sina
+end
+
+---Return the scale factor
+---@return number s
+function Transform:getScale()
+    return self.s
+end
+
+---Return the x and y coordinates
+---@return number x
+---@return number y
+function Transform:getTranslation()
+    return self.x, self.y
+end
+
+local function clamp(x, min, max)
+    return x < min and min or (x > max and max or x)
+end
+
+---Calculates the cos and sin terms of the product of 2 2x2 rotation matrices
+---
+---Multiplying a 2x2 matrix that has terms (cosa,sina) with one that has (cosb,sinb)
+---yields a rotation matrix with the terms (cosa*cosb - sina*sinb, cosa*sinb + cosb*sina)
+---@param ca number cos component of angle
+---@param sa number sin component of angle
+---@param rx ?number reference x coordinate defaults to centroid
+---@param ry ?number reference y coordinate defaults to centroid
+---@return Transform
+function Transform:rotate(ca, sa, rx, ry)
+    rx = rx or self.x
+    ry = ry or self.y
+    local cosa = clamp( ca*self.cosa - sa*self.sina , -1, 1)
+    local sina = clamp( sa*self.cosa + ca*self.sina , -1, 1)
+
+    self.cosa, self.sina = cosa, sina
+
+    -- rotate the translaton about the ref point
+    local dx, dy = self.x - rx, self.y - ry
+    self.x = ca*dx - sa*dy + rx
+    self.y = sa*dx + ca*dy + ry
+
+    return self
+end
+
+---Calls :rotate with decomposed angle 
+---@param a number angle in radians
+---@param rx ?number reference x coordinate defaults to centroid
+---@param ry ?number reference y coordinate defaults to centroid
+---@return Transform
+function Transform:rotateA(a, rx, ry)
+    return self:rotate(cos(a), sin(a), rx, ry)
+end
+
+---Sets the rotation components
+---@param ca number cos component of angle
+---@param sa number sin component of angle
+---@param rx ?number reference x coordinate defaults to centroid
+---@param ry ?number reference y coordinate defaults to centroid
+---@return Transform
+function Transform:rotateTo(ca, sa, rx, ry)
+    rx = rx or self.x
+    ry = ry or self.y
+    self.cosa = ca
+    self.sina = sa
+
+    -- rotate the translaton about the ref point
+    local dx, dy = self.x - rx, self.y - ry
+    self.x = ca*dx - sa*dy + rx
+    self.y = sa*dx + ca*dy + ry
+
+    return self
+end
+
+---Calls :rotateTo with decomposed angle 
+---@param a number angle in radians
+---@param rx ?number reference x coordinate defaults to centroid
+---@param ry ?number reference y coordinate defaults to centroid
+---@return Transform self
+function Transform:rotateToA(a, rx, ry)
+    return self:rotateTo(cos(a), sin(a), rx, ry)
+end
+
+---Modify points by a scale multiplier wrt a reference point
+---@param s number scale factor (multiplies w/ current scale)
+---@param sx number reference x coordinate (defaults to position) 
+---@param sy number reference y coordinate (defaults to position)
+---@return Transform self
+function Transform:scale(s, sx, sy)
+    self.s = self.s * s
+
+    -- scale the translaton about the ref point
+    local dx, dy = self.x - sx, self.y - sy
+    self.x = dx * self.s + sx
+    self.y = dy * self.s + sy
+
+    return self
+end
+
+---Sets the scale factor about a reference point
+---@param s number scale factor
+---@param sx number reference x coordinate (defaults to position) 
+---@param sy number reference y coordinate (defaults to position)
+---@return Transform self
+function Transform:scaleTo(s, sx, sy)
+    self.s = s
+
+    -- scale the translaton about the ref point
+    local dx, dy = self.x - sx, self.y - sy
+    self.x = dx * self.s + sx
+    self.y = dy * self.s + sy
+
+    return self
+end
+
+---Translates the current position by x and y
+---@param x number
+---@param y number
+---@return Transform self
+function Transform:translate(x, y)
+    self.x = self.x + x
+    self.y = self.y + y
+
+    return self
+end
+
+---Sets the current position
+---@param x number
+---@param y number
+---@return Transform self
+function Transform:translateTo(x, y)
+    self.x = x
+    self.y = y
+
+    return self
+end
+
+---Copy the given transform's values
+---@param t any
+---@return Transform self
+function Transform:setFromTransform(t)
+    self.x = t.x
+    self.y = t.y
+    self.cosa = t.cosa
+    self.sina = t.sina
+    self.s = t.s
+    return self
+end
+
+---Return a new copy of this transform
+---@return Transform
+function Transform:copy()
+    return Transform(self.x,self.y,self.cosa,self.sina)
+end
+
+---Given a point, return the transformed coordinates
+---Scale, rotate, translate
+---@param px number x coordinate of point to transform
+---@param py number y coordinate of point to transform
+---@return number px transformed x coordinate
+---@return number pytransformed y coordinate
+function Transform:transform(px, py)
+    px, py = px * self.s, py * self.s -- scale first
+    local x = self.cosa * px - self.sina * py + self.x
+    local y = self.sina * px + self.cosa * py + self.y
+    return x, y
+end
+
+return Transform

--- a/classes/Transform.lua
+++ b/classes/Transform.lua
@@ -1,7 +1,5 @@
 local Object = Libs.classic
 local cos, sin = math.cos, math.sin
----@type Pool
---local Pool = _Require_relative( ..., 'Pool')
 
 ---@class Transform : Object, Pool
 ---@field x number
@@ -9,9 +7,17 @@ local cos, sin = math.cos, math.sin
 ---@field cosa number cos term of a 2x2 rotation matrix
 ---@field sina number sin term of a 2x2 rotation matrix
 ---@field s number scale factor
-local Transform = Object:extend()--:implement(Pool)
+local Transform = Object:extend()
 
+---Constructor
+---@param x number x coordinate
+---@param y number y coordinate
+---@param ca number cos component of angle
+---@param sa number sin component of angle
+---@param s number scale factor
 function Transform:new(x, y, ca, sa, s)
+    ca = ca or 1
+    sa = sa or 0
     self.x = x or 0
     self.y = y or 0
     -- normalize rotation components
@@ -21,6 +27,12 @@ function Transform:new(x, y, ca, sa, s)
     self.s = s or 1
 end
 
+---Static constructor method
+---@param x number x coordinate
+---@param y number y coordinate
+---@param a number angle radians
+---@param s number scale factor
+---@return Transform
 function Transform.fromAngle(x, y, a, s)
     local cosa = a and cos(a) or 1
     local sina = a and sin(a) or 0

--- a/classes/Transform.lua
+++ b/classes/Transform.lua
@@ -14,8 +14,10 @@ local Transform = Object:extend()--:implement(Pool)
 function Transform:new(x, y, ca, sa, s)
     self.x = x or 0
     self.y = y or 0
-    self.cosa = ca or 1
-    self.sina = sa or 0
+    -- normalize rotation components
+    local m = (ca*ca + sa*sa)^0.5
+    self.cosa = ca/m
+    self.sina = sa/m
     self.s = s or 1
 end
 
@@ -45,10 +47,6 @@ function Transform:getTranslation()
     return self.x, self.y
 end
 
-local function clamp(x, min, max)
-    return x < min and min or (x > max and max or x)
-end
-
 ---Calculates the cos and sin terms of the product of 2 2x2 rotation matrices
 ---
 ---Multiplying a 2x2 matrix that has terms (cosa,sina) with one that has (cosb,sinb)
@@ -59,10 +57,17 @@ end
 ---@param ry ?number reference y coordinate defaults to centroid
 ---@return Transform
 function Transform:rotate(ca, sa, rx, ry)
+    ca = ca or 1
+    sa = sa or 0
     rx = rx or self.x
     ry = ry or self.y
-    local cosa = clamp( ca*self.cosa - sa*self.sina , -1, 1)
-    local sina = clamp( sa*self.cosa + ca*self.sina , -1, 1)
+    -- normalize rotation components
+    local m = (ca*ca + sa*sa)^0.5
+    ca = ca/m
+    sa = sa/m
+
+    local cosa = ca * self.cosa - sa * self.sina
+    local sina = sa * self.cosa + ca * self.sina
 
     self.cosa, self.sina = cosa, sina
 
@@ -90,10 +95,16 @@ end
 ---@param ry ?number reference y coordinate defaults to centroid
 ---@return Transform
 function Transform:rotateTo(ca, sa, rx, ry)
+    ca = ca or 1
+    sa = sa or 0
     rx = rx or self.x
     ry = ry or self.y
-    self.cosa = ca
-    self.sina = sa
+    -- normalize rotation components
+    local m = (ca*ca + sa*sa)^0.5
+    ca = ca/m
+    sa = sa/m
+
+    self.cosa, self.sina = ca, sa
 
     -- rotate the translaton about the ref point
     local dx, dy = self.x - rx, self.y - ry

--- a/colliders/Collider.lua
+++ b/colliders/Collider.lua
@@ -55,7 +55,6 @@ function Collider:elems(outer_iter)
                 if shape == nil then
                     iter, outer_iter = outer_iter, nil
                 elseif shape.type == 'collider' then
-                    --print(shape.type)
                     iter = shape:elems(iter)
                 else
                     return shape

--- a/colliders/Collider.lua
+++ b/colliders/Collider.lua
@@ -65,17 +65,17 @@ function Collider:elems(outer_iter)
 end
 
 ---Calculate area
----@return number area
+---@return Collider self
 function Collider:calcArea()
     self.area = 0
     for shape in self:elems() do
         self.area = self.area + shape.area
     end
-    return self.area
+    return self
 end
 
 ---Calculate centroid
----@return Point
+---@return Collider self
 function Collider:calcCentroid()
     self.centroid.x, self.centroid.y = 0,0
     local area = 0
@@ -86,12 +86,11 @@ function Collider:calcCentroid()
         self.centroid.y = self.centroid.y + sy * shape.area
     end
     self.centroid.x, self.centroid.y = self.centroid.x/area, self.centroid.y/area
-    return self.centroid
+    return self
 end
 
 ---Calculate area & centroid
----@return number
----@return Point
+---@return Collider self
 function Collider:calcAreaCentroid()
     self.centroid.x, self.centroid.y = 0,0
     self.area = 0
@@ -102,11 +101,11 @@ function Collider:calcAreaCentroid()
         self.centroid.y = self.centroid.y + sy * shape.area
     end
     self.centroid.x, self.centroid.y = self.centroid.x/self.area, self.centroid.y/self.area
-    return self.area, self.centroid
+    return self
 end
 
 ---Calc radius by finding shape with: largest sum of centroidal difference + radius
----@return number radius
+---@return Collider self
 function Collider:calcRadius()
     self.radius = 0
     local cx,cy = self.centroid.x, self.centroid.y
@@ -115,7 +114,7 @@ function Collider:calcRadius()
         local r = Vec.len(cx - sx, cy - sy) + shape.radius
         self.radius = self.radius > r and self.radius or r
     end
-    return self.radius
+    return self
 end
 
 function Collider:getRadius()

--- a/colliders/Collider.lua
+++ b/colliders/Collider.lua
@@ -80,9 +80,10 @@ function Collider:calcCentroid()
     self.centroid.x, self.centroid.y = 0,0
     local area = 0
     for shape in self:elems() do
+        local sx, sy = shape:getCentroid()
         area = area + shape.area
-        self.centroid.x = self.centroid.x + shape.centroid.x * shape.area
-        self.centroid.y = self.centroid.y + shape.centroid.y * shape.area
+        self.centroid.x = self.centroid.x + sx * shape.area
+        self.centroid.y = self.centroid.y + sy * shape.area
     end
     self.centroid.x, self.centroid.y = self.centroid.x/area, self.centroid.y/area
     return self.centroid
@@ -95,9 +96,10 @@ function Collider:calcAreaCentroid()
     self.centroid.x, self.centroid.y = 0,0
     self.area = 0
     for shape in self:elems() do
+        local sx, sy = shape:getCentroid()
         self.area = self.area + shape.area
-        self.centroid.x = self.centroid.x + shape.centroid.x * shape.area
-        self.centroid.y = self.centroid.y + shape.centroid.y * shape.area
+        self.centroid.x = self.centroid.x + sx * shape.area
+        self.centroid.y = self.centroid.y + sy * shape.area
     end
     self.centroid.x, self.centroid.y = self.centroid.x/self.area, self.centroid.y/self.area
     return self.area, self.centroid
@@ -109,7 +111,8 @@ function Collider:calcRadius()
     self.radius = 0
     local cx,cy = self.centroid.x, self.centroid.y
     for shape in self:elems() do
-        local r = Vec.len(cx - shape.centroid.x, cy - shape.centroid.y) + shape.radius
+        local sx, sy = shape:getCentroid()
+        local r = Vec.len(cx - sx, cy - sy) + shape.radius
         self.radius = self.radius > r and self.radius or r
     end
     return self.radius
@@ -314,8 +317,9 @@ function Collider:draw(mode)
     for shape in self:elems() do
         if mode == 'rainbow' then love.graphics.setColor(love.math.random(), love.math.random(), love.math.random()) end
         shape:draw(mode)
-        love.graphics.points(shape.centroid.x, shape.centroid.y)
-        love.graphics.print(_,shape.centroid.x, shape.centroid.y)
+        local sx, sy = shape:getCentroid()
+        love.graphics.points(sx, sy)
+        love.graphics.print(_, sx, sy)
     end
 end
 

--- a/init.lua
+++ b/init.lua
@@ -17,11 +17,9 @@ Libs = scandir('lib')
 for _, filename in ipairs(Libs) do
     local ext = filename:match("^.+(%..+)$")
     local name = ext == '.lua' and filename:gsub('.lua', '') or filename
-    print('lib name: '..name)
     Libs[name] = require( table.concat({..., 'lib',name},".") )
 end
 
 local Strike = require( table.concat({..., 'Strike'},".") )
-
 
 return Strike

--- a/scandir.lua
+++ b/scandir.lua
@@ -17,7 +17,6 @@ else
         directory = get_script_path() .. directory .. "."
         local i, t, popen = 0, {}, io.popen
         for filename in popen('dir "'..directory..'" /b'):lines() do
-            --print(filename)
             i = i + 1
             t[i] = filename
         end

--- a/shapes/Circle.lua
+++ b/shapes/Circle.lua
@@ -44,33 +44,33 @@ end
 
 -- We can't actually iterate over circle geometry, but we can return a single edge
 -- from the circle centroid to closest point of test shape
-local function get_closest_point(shape, p)
+local function get_closest_point(shape, x,y)
     local dist, min_dist, min_p
     for i, v in ipairs(shape.vertices) do
-        dist = Vec.dist2(p.x,p.y, v.x,v.y)
+        dist = Vec.dist2(x,y, v.x,v.y)
         if not min_dist or dist < min_dist then
             min_dist = dist
             min_p = v
         end
     end
-    return min_p
+    return min_p.x, min_p.y
 end
 
 local function iter_edges(state)
     local endx, endy
 	state.i = state.i + 1
-    local c = state.self.centroid
+    local cx, cy = state.self:getCentroid()
     local shape = state.shape
-    local sc = shape.centroid
+    local sx, sy = shape:getCentroid()
 	if state.i <= 1 then
         if shape.name == 'circle' then
-            endx, endy = sc.x, sc.y
+            endx, endy = sx, sy
         else
-            local mp = get_closest_point(shape, c)
+            local mp = get_closest_point(shape, cx, cy)
             endx, endy = mp.x, mp.y
         end
-        local normx, normy = Vec.perpendicular(Vec.sub(endx,endy, c.x,c.y))
-        return state.i, {c.x,c.y, c.x+normx,c.y+normy}
+        local normx, normy = Vec.perpendicular(Vec.sub(endx,endy, cx,cy))
+        return state.i, {cx, cy, cx+normx, cy+normy}
     end
 end
 
@@ -82,17 +82,16 @@ end
 local function iter_vecs(state)
     local endx, endy
 	state.i = state.i + 1
-    local c = state.self.centroid
+    local cx, cy = state.self:getCentroid()
     local shape = state.shape
-    local sc = shape.centroid
+    local sx, sy = shape:getCentroid()
 	if state.i <= 1 then
         if shape.name == 'circle' then
-            endx, endy = sc.x, sc.y
+            endx, endy = sx, sy
         else
-            local mp = get_closest_point(shape, c)
-            endx, endy = mp.x, mp.y
+            endx, endy = get_closest_point(shape, cx, cy)
         end
-        local normx, normy = Vec.perpendicular(Vec.sub(endx,endy, c.x,c.y))
+        local normx, normy = Vec.perpendicular(Vec.sub(endx,endy, cx,cy))
         return state.i, {x = normx, y = normy}
     end
 end
@@ -118,12 +117,14 @@ end
 
 ---Rotate by specified radians
 ---@param angle number radians
----@param refx number reference x-coordinate
----@param refy number reference y-coordinate
+---@param x number reference x-coordinate
+---@param y number reference y-coordinate
 ---@return Circle self
-function Circle:rotate(angle, refx, refy)
+function Circle:rotate(angle, x, y)
+    x = x or 0
+    y = y or 0
     local c = self.centroid
-    c.x, c.y = Vec.add(refx, refy, Vec.rotate(angle, c.x-refx, c.y - refy))
+    c.x, c.y = Vec.add(x, y, Vec.rotate(angle, c.x-x, c.y - y))
 	return self
 end
 

--- a/shapes/Circle.lua
+++ b/shapes/Circle.lua
@@ -27,10 +27,10 @@ function Circle:new(x, y, radius, angle)
 end
 
 ---Calculate area
----@return number area
+---@return Shape self
 function Circle:calcArea()
     self.area = pi*self.radius^2
-    return self.area
+    return self
 end
 
 ---comment

--- a/shapes/Circle.lua
+++ b/shapes/Circle.lua
@@ -45,15 +45,17 @@ end
 -- We can't actually iterate over circle geometry, but we can return a single edge
 -- from the circle centroid to closest point of test shape
 local function get_closest_point(shape, x,y)
-    local dist, min_dist, min_p
-    for i, v in ipairs(shape.vertices) do
-        dist = Vec.dist2(x,y, v.x,v.y)
+    local dist, min_dist, min_x, min_y
+    local len = #shape.vertices
+    for i = 1, len do
+        local vx, vy = shape:getVertex(i)
+        dist = Vec.dist2(x,y, vx,vy)
         if not min_dist or dist < min_dist then
             min_dist = dist
-            min_p = v
+            min_x, min_y = vx, vy
         end
     end
-    return min_p.x, min_p.y
+    return min_x, min_y
 end
 
 local function iter_edges(state)
@@ -66,8 +68,8 @@ local function iter_edges(state)
         if shape.name == 'circle' then
             endx, endy = sx, sy
         else
-            local mp = get_closest_point(shape, cx, cy)
-            endx, endy = mp.x, mp.y
+            local mpx, mpy = get_closest_point(shape, cx, cy)
+            endx, endy = mpx, mpy
         end
         local normx, normy = Vec.perpendicular(Vec.sub(endx,endy, cx,cy))
         return state.i, {cx, cy, cx+normx, cy+normy}

--- a/shapes/Circle.lua
+++ b/shapes/Circle.lua
@@ -16,13 +16,12 @@ Circle.name = 'circle'
 function Circle:new(x, y, radius, angle)
 	if not ( radius ) then return false end
     Circle.super.new(self)
-	x = x or 0
-	y = y or 0
 	-- Put everything into circle table and then return it
-	self.convex   = true                          -- boolean
-    self.radius   = radius				        -- radius of circumscribed circle
-    self.area     = pi*radius^2				    -- absolute/unsigned area of polygon
+	self.convex   = true        -- boolean
+    self.radius   = radius		-- radius of circumscribed circle
+    self.area     = pi*radius^2	-- absolute/unsigned area of polygon
     self.angle    = angle or 0
+    self:translateTo(x,y)
 end
 
 ---Calculate area

--- a/shapes/Circle.lua
+++ b/shapes/Circle.lua
@@ -20,7 +20,6 @@ function Circle:new(x, y, radius, angle)
 	y = y or 0
 	-- Put everything into circle table and then return it
 	self.convex   = true                          -- boolean
-    self.centroid = {x = x, y = y}  -- {x, y} coordinate pair
     self.radius   = radius				        -- radius of circumscribed circle
     self.area     = pi*radius^2				    -- absolute/unsigned area of polygon
     self.angle    = angle or 0
@@ -105,37 +104,6 @@ end
 function Circle:vecs(shape)
     local state = {self=self, shape=shape, i=0}
     return iter_vecs, state, nil
-end
-
----Translate by displacement vector
----@param dx number
----@param dy number
----@return Circle self
-function Circle:translate(dx, dy)
-    self.centroid.x, self.centroid.y = self.centroid.x + dx, self.centroid.y + dy
-	return self
-end
-
----Rotate by specified radians
----@param angle number radians
----@param x number reference x-coordinate
----@param y number reference y-coordinate
----@return Circle self
-function Circle:rotate(angle, x, y)
-    x = x or 0
-    y = y or 0
-    local c = self.centroid
-    c.x, c.y = Vec.add(x, y, Vec.rotate(angle, c.x-x, c.y - y))
-	return self
-end
-
----Scale circle
----@param sf number scale factor
----@return Circle self
-function Circle:scale(sf)
-    self.radius = self.radius * sf
-    self:calcArea()
-	return self
 end
 
 ---Project circle along normalized vector

--- a/shapes/Circle.lua
+++ b/shapes/Circle.lua
@@ -117,10 +117,13 @@ function Circle:project(nx, ny)
     return proj - self.radius, proj + self.radius
 end
 
+---Get an edge given an index, returns the vertex at i and the vertex at i+1
+---@param i number edge index (has to be 1)
+---@return table|nil edge of form {x1,y1, x2,y2} or nil if index beyond bounds
 function Circle:getEdge(i)
     local cx, cy = self:getCentroid()
     local r = self.radius
-    return i == 1 and {cx, cy, cx + r, cy + r} or false
+    return i == 1 and {cx, cy, cx + r, cy + r} or nil
 end
 
 ---Test if point inside circle

--- a/shapes/Circle.lua
+++ b/shapes/Circle.lua
@@ -13,14 +13,14 @@ Circle.name = 'circle'
 ---@param y number y coordinate
 ---@param radius number
 ---@param angle number angle offset
----@return boolean
 function Circle:new(x, y, radius, angle)
 	if not ( radius ) then return false end
-	local x_offset = x or 0
-	local y_offset = y or 0
+    Circle.super.new(self)
+	x = x or 0
+	y = y or 0
 	-- Put everything into circle table and then return it
 	self.convex   = true                          -- boolean
-    self.centroid = {x = x_offset, y = y_offset}  -- {x, y} coordinate pair
+    self.centroid = {x = x, y = y}  -- {x, y} coordinate pair
     self.radius   = radius				        -- radius of circumscribed circle
     self.area     = pi*radius^2				    -- absolute/unsigned area of polygon
     self.angle    = angle or 0

--- a/shapes/Circle.lua
+++ b/shapes/Circle.lua
@@ -39,7 +39,8 @@ end
 ---@return number dx width
 ---@return number dy height
 function Circle:getBbox()
-    return self.centroid.x - self.radius, self.centroid.y - self.radius, self.radius, self.radius
+    local cx, cy = self:getCentroid()
+    return cx - self.radius, cy - self.radius, self.radius, self.radius
 end
 
 -- We can't actually iterate over circle geometry, but we can return a single edge
@@ -142,19 +143,22 @@ end
 ---@param ny number normalized y-component
 ---@return number minimum, number maximumum smallest, largest projection
 function Circle:project(nx, ny)
-    local proj = Vec.dot(self.centroid.x, self.centroid.y, nx, ny)
+    local cx, cy = self:getCentroid()
+    local proj = Vec.dot(cx, cy, nx, ny)
     return proj - self.radius, proj + self.radius
 end
 
 function Circle:getEdge(i)
-    local c, r = self.centroid, self.radius
-    return i == 1 and {c.x, c.y, c.x + r, c.y + r} or false
+    local cx, cy = self:getCentroid()
+    local r = self.radius
+    return i == 1 and {cx, cy, cx + r, cy + r} or false
 end
 
 ---Test if point inside circle
 ---@param point Point
 function Circle:containsPoint(point)
-    return Vec.len2(Vec.sub(point.x,point.y, self.centroid.x, self.centroid.y)) <= self.radius*self.radius
+    local cx, cy = self:getCentroid()
+    return Vec.len2(Vec.sub(point.x,point.y, cx, cy)) <= self.radius*self.radius
 end
 
 ---Test of normalized ray hits circle
@@ -183,7 +187,8 @@ function Circle:rayIntersections(x,y, dx,dy, ts)
     if not self:rayIntersects(x,y, dx,dy) then return nil end
     ts = ts or {}
     dx, dy = Vec.normalize(dx, dy)
-    local lx, ly = Vec.sub(self.centroid.x, self.centroid.y, x, y)
+    local cx, cy = self:getCentroid()
+    local lx, ly = Vec.sub(cx, cy, x, y)
     local h = Vec.dot(lx,ly, dx, dy)
     local d = Vec.len(Vec.reject(lx,ly, dx,dy))
     local r = math.sqrt(self.radius*self.radius - d*d)
@@ -198,7 +203,9 @@ end
 ---@return number y
 ---@return number radius
 function Circle:unpack()
-    return self.centroid.x, self.centroid.y, self.radius
+    local cx, cy = self:getCentroid()
+    local r = self:getRadius()
+    return cx, cy, r
 end
 
 function Circle:merge()
@@ -210,8 +217,9 @@ end
 ---@param ny number normalized y dir
 ---@return table Max-Point
 function Circle:getSupport(nx,ny)
+    local cx, cy = self:getCentroid()
     local px,py = Vec.mul(self.radius, nx,ny)
-    return {x=self.centroid.x+px, y= self.centroid.y+py}
+    return {x = cx+px, y = cy+py}
 end
 
 ---Get the point involved in a collision

--- a/shapes/ConvexPolygon.lua
+++ b/shapes/ConvexPolygon.lua
@@ -2,10 +2,10 @@ local abs, min, max, atan2 	= math.abs, math.min, math.max, math.atan2
 local push = table.insert
 local tbl = Libs.tbl
 local Vec = _Require_relative(..., 'lib.DeWallua.vector-light',1)
-local Shape = _Require_relative(...,"Shape")
+local VertexShape = _Require_relative(...,"VertexShape")
 
 ---@class ConvexPolygon : Shape
-ConvexPolygon = Shape:extend()
+ConvexPolygon = VertexShape:extend()
 ConvexPolygon.name = 'convex'
 
 -- Recursive function that returns a list of {x=#,y=#} coordinates given a list of procedural, ccw coordinate pairs

--- a/shapes/ConvexPolygon.lua
+++ b/shapes/ConvexPolygon.lua
@@ -125,7 +125,7 @@ local function order_points_ccw(vertices)
 end
 
 ---Calculate polygon area using shoelace algorithm
----@return number area
+---@return Shape self
 function ConvexPolygon:calcArea()
 	local vertices = self.vertices
 	-- Initialize p and q so we can wrap around in the loop
@@ -143,12 +143,11 @@ function ConvexPolygon:calcArea()
 	end
 
 	self.area = area * 0.5
-	return self.area
+	return self
 end
 
 ---Calculate centroid and area of the polygon at the _same_ time
----@return number area
----@return table centroid
+---@return Shape self
 function ConvexPolygon:calcAreaCentroid()
 	local vertices = self.vertices
 	-- Initialize p and q so we can wrap around in the loop
@@ -169,18 +168,18 @@ function ConvexPolygon:calcAreaCentroid()
 	self.area = self.area * 0.5
 	self.centroid.x	= self.centroid.x / (6*self.area);
     self.centroid.y	= self.centroid.y / (6*self.area);
-	return self.area, self.centroid
+	return self
 end
 
 ---Calculate polygon radius
----@return number radius
+---@return Shape self
 function ConvexPolygon:calcRadius()
 	local vertices, radius = self.vertices, 0
 	for i = 1,#vertices do
 		radius = max(radius, Vec.dist(vertices[i].x,vertices[i].y, self.centroid.x, self.centroid.y))
 	end
 	self.radius = radius
-	return self.radius
+	return self
 end
 
 ---Get polygon bounding box

--- a/shapes/ConvexPolygon.lua
+++ b/shapes/ConvexPolygon.lua
@@ -8,17 +8,6 @@ local VertexShape = _Require_relative(...,"VertexShape")
 ConvexPolygon = VertexShape:extend()
 ConvexPolygon.name = 'convex'
 
--- Recursive function that returns a list of {x=#,y=#} coordinates given a list of procedural, ccw coordinate pairs
-local function to_verts(vertices, x, y, ...)
-    if not (x and y) then return vertices end
-	vertices[#vertices + 1] = {x = x, y = y} -- , dx = 0, dy = 0}   -- set vertex
-	return to_verts(vertices, ...)
-end
-
-local function to_vertices(vertices, x, ...)
-	return type(x) == 'table'and to_verts(vertices, unpack(x)) or to_verts(vertices, x,...)
-end
-
 -- Test if 3 points are collinear (do they not make a triangle?)
 local function is_collinear(a, b, c)
 	return abs(Vec.det(a.x-c.x, a.y-c.y, b.x-c.x,b.y-c.y)) <= 1e-32
@@ -227,7 +216,7 @@ end
 ---@param x number
 ---@param y number
 function ConvexPolygon:new(x,y, ...)
-    self.vertices = to_vertices({}, x,y, ...)
+    ConvexPolygon.super.new(self, x,y, ...)
 	assert(#self.vertices >= 3, "Need at least 3 non collinear points to build polygon (got "..#self.vertices..")")
 	if not is_convex(self.vertices) then
 		assert(order_points_ccw(self.vertices), 'Points cannot be ordered into a convex shape')

--- a/shapes/ConvexPolygon.lua
+++ b/shapes/ConvexPolygon.lua
@@ -229,6 +229,16 @@ function ConvexPolygon:new(x,y, ...)
 	self:calcRadius()
 end
 
+---Get a vertex by its offset
+---@param i number
+---@return number|false v.x or false if beyond range
+---@return number|false v.y
+function ConvexPolygon:getVertex(i)
+	if i > #self.vertices then return false, false end
+	local v = self.vertices[i]
+	return v.x, v.y
+end
+
 local function iter_edges(shape, i)
 	i = i + 1
 	local v = shape.vertices

--- a/shapes/ConvexPolygon.lua
+++ b/shapes/ConvexPolygon.lua
@@ -242,16 +242,6 @@ function ConvexPolygon:new(x,y, ...)
 	self:calcRadius()
 end
 
----Get a vertex by its offset
----@param i number
----@return number|false v.x or false if beyond range
----@return number|false v.y
-function ConvexPolygon:getVertex(i)
-	if i > #self.vertices then return false, false end
-	local v = self.vertices[i]
-	return v.x, v.y
-end
-
 local function iter_edges(shape, i)
 	i = i + 1
 	local len, ix, iy = #shape.vertices, shape:getVertex(i)

--- a/shapes/ConvexPolygon.lua
+++ b/shapes/ConvexPolygon.lua
@@ -174,10 +174,10 @@ function ConvexPolygon:calcAreaCentroid()
 		self.area = self.area + a
 	end
 	self.area = self.area * 0.5
-	self:translateTo(
-		cx / (6*self.area),
-		cy / (6*self.area)
-	)
+	self.centroid = {
+		x = cx / (6*self.area),
+		y = cy / (6*self.area)
+	}
 	return self
 end
 

--- a/shapes/ConvexPolygon.lua
+++ b/shapes/ConvexPolygon.lua
@@ -29,6 +29,10 @@ local function is_ccw(p, q, r)
 	return Vec.det(q.x-p.x, q.y-p.y,  r.x-p.x, r.y-p.y) >= 0
 end
 
+local function is_ccw_scalar(px,py, qx,qy, rx,ry)
+	return Vec.det(qx-px, qy-py,  rx-px, ry-py) >= 0
+end
+
 -- Remove vertices that are collinear
 local function trim_collinear(vertices)
 	local trimmed = {}
@@ -127,18 +131,20 @@ end
 ---Calculate polygon area using shoelace algorithm
 ---@return Shape self
 function ConvexPolygon:calcArea()
-	local vertices = self.vertices
+	local len = #self.vertices
 	-- Initialize p and q so we can wrap around in the loop
-	local p, q = vertices[#vertices], vertices[1]
-	-- a is the signed area of the triangle formed by the two legs of p.x-q.x and p.y-q.y - it is our weighting
-	local a = Vec.det(p.x,p.y, q.x,q.y)
+	local px, py = self:getVertex(len)
+	local qx, qy = self:getVertex(1)
+	-- a is the signed area of the triangle formed by the two legs of px - qx and py - qy - it is our weighting
+	local a = Vec.det(px,py, qx,qy)
 	-- signed_area is the total signed area of all triangles
 	local area = a
 
-	for i = 2, #vertices do
+	for i = 2, len do
 		-- Now assign p to q, q to next
-		p, q = q, vertices[i]
-		a = Vec.det(p.x,p.y, q.x,q.y)
+		px,py = qx,qy
+		qx,qy = self:getVertex(i)
+		a = Vec.det(px,py, qx,qy)
 		area = area + a
 	end
 
@@ -149,34 +155,40 @@ end
 ---Calculate centroid and area of the polygon at the _same_ time
 ---@return Shape self
 function ConvexPolygon:calcAreaCentroid()
-	local vertices = self.vertices
+	local len = #self.vertices
 	-- Initialize p and q so we can wrap around in the loop
-	local p, q = vertices[#vertices], vertices[1]
-	-- a is the area of the triangle formed by the two legs of p.x-q.x and p.y-q.y - it is our weighting
-	local a = Vec.det(p.x,p.y, q.x,q.y)
+	local px, py = self:getVertex(len)
+	local qx, qy = self:getVertex(1)
+	-- a is the signed area of the triangle formed by the two legs of px - qx and py - qy - it is our weighting
+	local a = Vec.det(px,py, qx,qy)
 	-- area is the total area of all triangles
 	self.area = a
-	self.centroid = {x = (p.x+q.x)*a, y = (p.y+q.y)*a}
+	local cx, cy = (px+qx)*a, (py+qy)*a
 
-	for i = 2, #vertices do
-		-- Now cycle p to q, q to next vertex
-		p, q = q, vertices[i]
-		a = Vec.det(p.x,p.y, q.x,q.y)
-		self.centroid.x, self.centroid.y = self.centroid.x + (p.x+q.x)*a, self.centroid.y + (p.y+q.y)*a
+	for i = 2, len do
+		-- Now assign p to q, q to next
+		px,py = qx,qy
+		qx,qy = self:getVertex(i)
+		a = Vec.det(px,py, qx,qy)
+		cx, cy = cx + (px+qx)*a, cy + (py+qy)*a
 		self.area = self.area + a
 	end
 	self.area = self.area * 0.5
-	self.centroid.x	= self.centroid.x / (6*self.area);
-    self.centroid.y	= self.centroid.y / (6*self.area);
+	self:translateTo(
+		cx / (6*self.area),
+		cy / (6*self.area)
+	)
 	return self
 end
 
 ---Calculate polygon radius
 ---@return Shape self
 function ConvexPolygon:calcRadius()
+	local cx, cy = self:getCentroid()
 	local vertices, radius = self.vertices, 0
 	for i = 1,#vertices do
-		radius = max(radius, Vec.dist(vertices[i].x,vertices[i].y, self.centroid.x, self.centroid.y))
+		local vx, vy = self:getVertex(i)
+		radius = max(radius, Vec.dist(vx,vy, cx,cy))
 	end
 	self.radius = radius
 	return self
@@ -185,10 +197,11 @@ end
 ---Get polygon bounding box
 ---@return number x, number y, number dx, number dy minimum x/y, width, and height
 function ConvexPolygon:getBbox()
-	local min_x, max_x, min_y, max_y = self.vertices[1].x,self.vertices[1].x, self.vertices[1].y, self.vertices[1].y
+	local min_x, min_y = self:getVertex(1)
+	local max_x, max_y = min_x, min_y
 	local x, y--, bbox
-	for __, vertex in ipairs(self.vertices) do
-		x, y = vertex.x, vertex.y
+	for i = 1, #self.vertices do
+		x, y = self:getVertex(i)
 		if x < min_x then min_x = x end
 		if x > max_x then max_x = x end
 		if y < min_y then min_y = y end
@@ -241,10 +254,11 @@ end
 
 local function iter_edges(shape, i)
 	i = i + 1
-	local v = shape.vertices
-	if i <= #v then
-		local j = i < #v and i+1 or 1
-		return i, {v[i].x, v[i].y, v[j].x, v[j].y}
+	local len, ix, iy = #shape.vertices, shape:getVertex(i)
+	if i <= len then
+		local j = i < len and i+1 or 1
+		local jx, jy = shape:getVertex(j)
+		return i, {ix, iy, jx, jy}
 	end
 end
 
@@ -256,12 +270,18 @@ function ConvexPolygon:ipairs()
     return iter_edges, self, 0
 end
 
+---comment
+---@param shape ConvexPolygon
+---@param i number
+---@return integer
+---@return table
 local function iter_vecs(shape, i)
 	i = i + 1
-	local v = shape.vertices
-	if i <= #v then
-		local j = i < #v and i+1 or 1
-		return i, {x = v[j].x - v[i].x, y = v[j].y - v[i].y}
+	local len, ix, iy = #shape.vertices, shape:getVertex(i)
+	if i <= len then
+		local j = i < len and i+1 or 1
+		local jx, jy = shape:getVertex(j)
+		return i, {x = jx - ix, y = jy - iy}
 	end
 end
 
@@ -345,13 +365,13 @@ function ConvexPolygon:project(nx,ny)
 	local proj_x, proj_y
 	local p, min_dot, max_dot
 	-- Project each point onto vector <nx, ny>
-	proj_x, proj_y = vertices[1].x, vertices[1].y
+	proj_x, proj_y = self:getVertex(1)
 	-- Init our min/max dot products (Can't init to random value)
 	min_dot = Vec.dot(proj_x,proj_y, nx,ny)
 	max_dot = min_dot
 	-- Create new projection vectors, dot-prod them with the input vector, and return the min/max
 	for i = 2, #vertices do
-		proj_x, proj_y = vertices[i].x , vertices[i].y
+		proj_x, proj_y = self:getVertex(i)
 		p = Vec.dot(proj_x,proj_y, nx,ny)
 		if p < min_dot then min_dot = p elseif p > max_dot then max_dot = p end
 	end
@@ -360,28 +380,31 @@ end
 
 ---Get an edge by index
 ---@param i number
----@return table {x1,y1, x2,y2}
+---@return table|false res edge of form {x1,y1, x2,y2} or false if index out of range
 function ConvexPolygon:getEdge(i)
 	if i > #self.vertices then return false end
 	local verts = self.vertices
 	local j = i < #verts and i+1 or 1
-	local p1, p2 = verts[i], verts[j]
-	return {p1.x, p1.y, p2.x, p2.y}
+	local p1x, p1y = self:getVertex(i)
+	local p2x, p2y = self:getVertex(j)
+	return {p1x, p1y, p2x, p2y}
 end
 
 --- Need this to test if a shape is completely inside
 ---@param point Point
 function ConvexPolygon:containsPoint(point)
-	local vertices = self.vertices
+	local len = #self.vertices
 	local winding = 0
-	local p, q = vertices[#vertices], vertices[1]
-	for i = 1, #vertices do
-		if p.y < point.y then
-			if q.y > point.y and is_ccw(p,q, point) then
+	local px, py = self:getVertex(len)
+	local qx, qy = self:getVertex(1)
+	local rx, ry = point.x, point.y
+	for i = 1, len do
+		if py < point.y then
+			if qy > point.y and is_ccw_scalar(px,py, qx,qy, rx,ry) then
 				winding = winding + 1
 			end
 		else
-			if q.y < point.y and not is_ccw(p,q, point) then
+			if qy < point.y and not is_ccw_scalar(px,py, qx,qy, rx,ry) then
 				winding = winding - 1
 			end
 		end
@@ -442,7 +465,8 @@ local function get_incident_edge(poly1, poly2)
     -- Iterate over poly_1's vertices, add x/y coords as keys to pmap
     local v1 = poly1.vertices
     for i = 1, #v1 do
-		local key = v1[i].x..'-'..v1[i].y
+		local v1x, v1y = poly1:getVertex(i)
+		local key = v1x..'-'..v1y
         p_map[key] = i
     end
     -- Now look through poly_2's vertices and see if there's a match
@@ -450,8 +474,9 @@ local function get_incident_edge(poly1, poly2)
     local i = #v2
     for j = 1, #v2 do
         -- Set p and q to reference poly_2's vertices at i and j
-        local p, q = v2[i], v2[j]
-		local kp, kq = p.x..'-'..p.y, q.x..'-'..q.y
+        local px, py = poly2:getVertex(i)
+		local qx, qy = poly2:getVertex(j)
+		local kp, kq = px..'-'..py, qx..'-'..qy
         -- Access p_map based on line p-q's two coordinates
         if p_map[kp] and p_map[kq] then
             -- Return the indices of the edge in both polygons
@@ -482,15 +507,17 @@ local function merge_convex_incident(poly1, poly2)
 	for i = 1, #v1 do
 		-- Skip the vertex if it's part of the poly_2's half of the incident edge
 		if i ~= j_1 then
-			push(union, v1[i].x)
-			push(union, v1[i].y)
+			local x,y = poly1:getVertex(i)
+			push(union, x)
+			push(union, y)
 		end
 	end
 	-- Do the same for poly2
 	for i = 1, #v2 do
 		if i ~= i_2 then
-			push(union, v2[i].x)
-			push(union, v2[i].y)
+			local x,y = poly2:getVertex(i)
+			push(union, x)
+			push(union, y)
 		end
 	end
 	return ConvexPolygon(union)
@@ -501,8 +528,9 @@ ConvexPolygon.merge = merge_convex_incident
 ---Contact Functions
 function ConvexPolygon:getSupport(nx,ny)
     local maxd, index = -math.huge , 1
-    for i, point in ipairs(self.vertices) do
-        local projection = Vec.dot(point.x,point.y, nx,ny)
+    for i = 1, #self.vertices do
+		local px,py = self:getVertex(i)
+        local projection = Vec.dot(px,py, nx,ny)
         if projection > maxd then
             maxd = projection
             index = i
@@ -521,17 +549,17 @@ function ConvexPolygon:getFeature(nx,ny)
     -- get farthest point in direction of normal
     local index = self:getSupport(nx,ny)
     -- test adjacent points to find edge most perpendicular to normal
-    local v = verts[index]
+    local vx, vy = self:getVertex(index)
     local i0 = index - 1 >= 1 and index - 1 or #verts
     local i1 = index + 1 <= #verts and index + 1 or 1
-    local v0 = verts[i0]
-    local v1 = verts[i1]
-    local gx,gy = Vec.normalize( Vec.sub(v.x,v.y, v0.x,v0.y) )
-    local hx,hy = Vec.normalize( Vec.sub(v.x,v.y, v1.x,v1.y) )
+    local v0x, v0y = self:getVertex(i0)
+    local v1x, v1y = self:getVertex(i1)
+    local gx,gy = Vec.normalize( Vec.sub(vx,vy, v0x,v0y) )
+    local hx,hy = Vec.normalize( Vec.sub(vx,vy, v1x,v1y) )
     if math.abs(Vec.dot(gx,gy, nx,ny)) <= math.abs(Vec.dot(hx,hy, nx,ny)) then
-        return {x=v.x,y=v.y}, {{x=v0.x,y=v0.y}, {x=v.x,y=v.y}}
+        return {x=vx,y=vy}, {{x=v0x,y=v0y}, {x=vx,y=vy}}
     else
-        return {x=v.x,y=v.y}, {{x=v.x,y=v.y}, {x=v1.x,y=v1.y}}
+        return {x=vx,y=vy}, {{x=vx,y=vy}, {x=v1x,y=v1y}}
     end
 end
 
@@ -541,7 +569,9 @@ if love and love.graphics then
 	function ConvexPolygon:draw(mode)
 		-- default fill to "line"
 		mode = mode or "line"
-		love.graphics.polygon(mode, self:_get_verts())
+		for i, edge in self:ipairs() do
+			love.graphics.line(unpack(edge))
+		end
 	end
 end
 

--- a/shapes/ConvexPolygon.lua
+++ b/shapes/ConvexPolygon.lua
@@ -1,10 +1,10 @@
-local abs, min, max, atan2 	= math.abs, math.min, math.max, math.atan2
+local abs, max, atan2 	= math.abs, math.max, math.atan2
 local push = table.insert
 local tbl = Libs.tbl
 local Vec = _Require_relative(..., 'lib.DeWallua.vector-light',1)
 local VertexShape = _Require_relative(...,"VertexShape")
 
----@class ConvexPolygon : Shape
+---@class ConvexPolygon : VertexShape
 ConvexPolygon = VertexShape:extend()
 ConvexPolygon.name = 'convex'
 
@@ -231,144 +231,6 @@ function ConvexPolygon:new(x,y, ...)
 	self:calcRadius()
 end
 
-local function iter_edges(shape, i)
-	i = i + 1
-	local len, ix, iy = #shape.vertices, shape:getVertex(i)
-	if i <= len then
-		local j = i < len and i+1 or 1
-		local jx, jy = shape:getVertex(j)
-		return i, {ix, iy, jx, jy}
-	end
-end
-
----Edge Iterator
----@return function
----@return ConvexPolygon
----@return number
-function ConvexPolygon:ipairs()
-    return iter_edges, self, 0
-end
-
----comment
----@param shape ConvexPolygon
----@param i number
----@return integer
----@return table
-local function iter_vecs(shape, i)
-	i = i + 1
-	local len, ix, iy = #shape.vertices, shape:getVertex(i)
-	if i <= len then
-		local j = i < len and i+1 or 1
-		local jx, jy = shape:getVertex(j)
-		return i, {x = jx - ix, y = jy - iy}
-	end
-end
-
----Iterate over edge vectors
----@return function
----@return ConvexPolygon
----@return number
-function ConvexPolygon:vecs()
-    return iter_vecs, self, 0
-end
-
----Translate by displacement vector
----@param dx number
----@param dy number
----@return ConvexPolygon self
-function ConvexPolygon:translate(dx, dy)
-	-- Translate each vertex by dx, dy
-	local vertices = self.vertices
-    for i = 1, #vertices do
-        vertices[i].x = vertices[i].x + dx
-        vertices[i].y = vertices[i].y + dy
-    end
-	-- Translate centroid
-	self.centroid.x = self.centroid.x + dx
-	self.centroid.y = self.centroid.y + dy
-    return self
-end
-
----Rotate by specified radians
----@param angle number radians
----@param refx number reference x-coordinate
----@param refy number reference y-coordinate
----@return ConvexPolygon self
-function ConvexPolygon:rotate(angle, refx, refy)
-	-- Default to centroid as ref-point
-    refx = refx or self.centroid.x
-	refy = refy or self.centroid.y
-	-- Rotate each vertex about ref-point
-    for i = 1, #self.vertices do
-        local v = self.vertices[i]
-        v.x, v.y = Vec.add(refx, refy, Vec.rotate(angle, v.x-refx, v.y - refy))
-    end
-	self.centroid.x, self.centroid.y = Vec.add(refx, refy, Vec.rotate(angle, self.centroid.x-refx, self.centroid.y-refy))
-	self.angle = self.angle + angle
-	return self
-end
-
---- scale helper function
-local function scale_p(x,y, sf,rx,ry)
-	return Vec.add(rx, ry, Vec.mul(sf, x-rx, y - ry))
-end
-
----Scale polygon
----@param sf number scale factor
----@param refx number reference x-coordinate
----@param refy number reference y-coordinate
----@return ConvexPolygon self
-function ConvexPolygon:scale(sf, refx, refy)
-	-- Default to centroid as ref-point
-	local c = self.centroid
-    refx = refx or c.x
-	refy = refy or c.y
-	-- Push each vertex out from the ref point by scale-factor
-    for i = 1, #self.vertices do
-        local v = self.vertices[i]
-        v.x, v.y = scale_p(v.x,v.y, sf,refx,refy)
-    end
-	c.x, c.y = scale_p(c.x, c.y, sf, refx, refy)
-    -- Recalculate area, and radius
-    self.area = self.area * sf * sf
-    self.radius = self.radius * sf
-	return self
-end
-
----Project polygon along normalized vector
----@param nx number normalized x-component
----@param ny number normalized y-component
----@return number minimum, number maximumum smallest, largest projection
-function ConvexPolygon:project(nx,ny)
-	local vertices = self.vertices
-	local proj_x, proj_y
-	local p, min_dot, max_dot
-	-- Project each point onto vector <nx, ny>
-	proj_x, proj_y = self:getVertex(1)
-	-- Init our min/max dot products (Can't init to random value)
-	min_dot = Vec.dot(proj_x,proj_y, nx,ny)
-	max_dot = min_dot
-	-- Create new projection vectors, dot-prod them with the input vector, and return the min/max
-	for i = 2, #vertices do
-		proj_x, proj_y = self:getVertex(i)
-		p = Vec.dot(proj_x,proj_y, nx,ny)
-		if p < min_dot then min_dot = p elseif p > max_dot then max_dot = p end
-	end
-	return min_dot, max_dot
-end
-
----Get an edge by index
----@param i number
----@return table|false res edge of form {x1,y1, x2,y2} or false if index out of range
-function ConvexPolygon:getEdge(i)
-	if i > #self.vertices then return false end
-	local verts = self.vertices
-	local j = i < #verts and i+1 or 1
-	local p1x, p1y = self:getVertex(i)
-	local p2x, p2y = self:getVertex(j)
-	return {p1x, p1y, p2x, p2y}
-end
-
 --- Need this to test if a shape is completely inside
 ---@param point Point
 function ConvexPolygon:containsPoint(point)
@@ -389,47 +251,6 @@ function ConvexPolygon:containsPoint(point)
 		end
 	end
 	return winding ~= 0
-end
-
----Project each individual edge instead of using self:project like in Circle
----@param x number ray origin
----@param y number ray origin
----@param dx number normalized x component
----@param dy number normalized y component
----@return boolean hit
-function ConvexPolygon:rayIntersects(x,y, dx,dy)
-	dx, dy = Vec.perpendicular(dx,dy)
-    local d = Vec.dot(x,y, dx,dy)
-	for i, edge in self:ipairs() do
-		local e1 = Vec.dot(edge[1],edge[2], dx,dy)
-		local e2 = Vec.dot(edge[3],edge[4], dx,dy)
-		if (e1-d) * (e2-d) <= 0 then return true end
-	end
-	return false
-end
-
--- https://stackoverflow.com/a/32146853/12135804
----Return all intersections as distances along ray
----@param x number ray origin
----@param y number ray origin
----@param dx number normalized x component
----@param dy number normalized y component
----@param ts table
----@return table | nil intersections
-function ConvexPolygon:rayIntersections(x,y, dx,dy, ts)
-	local v1x, v1y, v2x, v2y
-	local nx, ny = -dy, dx
-	ts = ts or {}
-	for i, edge in self:ipairs() do
-		v1x, v1y = Vec.sub(x, y, edge[1], edge[2])
-		v2x, v2y = Vec.sub(edge[3], edge[4], edge[1], edge[2])
-		local dot = Vec.dot(v2x, v2y, nx, ny)
-		if abs(dot) < 0.0001 then break end
-		local t1 = Vec.det(v2x,v2y, v1x,v1y) / dot
-		local t2 = Vec.dot(v1x,v1y, nx,ny) / dot
-		if t1 >= 0 and (t2 >= 0 and t2 <= 1) then push(ts, t1) end
-	end
-	return #ts > 0 and ts or nil
 end
 
 ConvexPolygon._get_verts = ConvexPolygon.unpack
@@ -503,44 +324,6 @@ local function merge_convex_incident(poly1, poly2)
 end
 
 ConvexPolygon.merge = merge_convex_incident
-
----Contact Functions
-function ConvexPolygon:getSupport(nx,ny)
-    local maxd, index = -math.huge , 1
-    for i = 1, #self.vertices do
-		local px,py = self:getVertex(i)
-        local projection = Vec.dot(px,py, nx,ny)
-        if projection > maxd then
-            maxd = projection
-            index = i
-        end
-    end
-    return index
-end
-
----Get the edge involved in a collision
----@param nx number normalized x dir
----@param ny number normalized y dir
----@return table Max-Point
----@return table Edge
-function ConvexPolygon:getFeature(nx,ny)
-    local verts = self.vertices
-    -- get farthest point in direction of normal
-    local index = self:getSupport(nx,ny)
-    -- test adjacent points to find edge most perpendicular to normal
-    local vx, vy = self:getVertex(index)
-    local i0 = index - 1 >= 1 and index - 1 or #verts
-    local i1 = index + 1 <= #verts and index + 1 or 1
-    local v0x, v0y = self:getVertex(i0)
-    local v1x, v1y = self:getVertex(i1)
-    local gx,gy = Vec.normalize( Vec.sub(vx,vy, v0x,v0y) )
-    local hx,hy = Vec.normalize( Vec.sub(vx,vy, v1x,v1y) )
-    if math.abs(Vec.dot(gx,gy, nx,ny)) <= math.abs(Vec.dot(hx,hy, nx,ny)) then
-        return {x=vx,y=vy}, {{x=v0x,y=v0y}, {x=vx,y=vy}}
-    else
-        return {x=vx,y=vy}, {{x=vx,y=vy}, {x=v1x,y=v1y}}
-    end
-end
 
 if love and love.graphics then
 	---Draw polygon w/ LOVE

--- a/shapes/Edge.lua
+++ b/shapes/Edge.lua
@@ -41,10 +41,7 @@ end
 ---@param y2 number y coordinate of second point
 function Edge:new(x1,y1, x2,y2)
 
-	self.vertices = {
-		{x = x1, y = y1},
-		{x = x2, y = y2}
-	}
+	Edge.super.new(self, x1,y1, x2,y2)
 
 	self.centroid = {
 		x = (x1 + x2) / 2,

--- a/shapes/Edge.lua
+++ b/shapes/Edge.lua
@@ -44,18 +44,9 @@ end
 ---@param x2 number x coordinate of second point
 ---@param y2 number y coordinate of second point
 function Edge:new(x1,y1, x2,y2)
-
 	Edge.super.new(self, x1,y1, x2,y2)
-
-	self.centroid = {
-		x = (x1 + x2) / 2,
-		y = (y1 + y2) / 2
-	}
-	self.radius = 0.5 * Vec.len(Vec.sub(x1,y1, x2,y2))
-	self.area = 1
 	self.norm = 0
 	self.angle = 0
-	self:calcAreaCentroid()
 end
 
 -- Only iterate once

--- a/shapes/Edge.lua
+++ b/shapes/Edge.lua
@@ -1,8 +1,8 @@
 local Vec = _Require_relative(..., 'lib.DeWallua.vector-light',1)
-local Polygon = _Require_relative(..., 'ConvexPolygon')
+local VertexShape = _Require_relative(..., 'VertexShape')
 
 ---@class Edge : Shape
-local Edge = Polygon:extend()
+local Edge = VertexShape:extend()
 Edge.name = 'edge'
 
 ---"Calculate" edge area

--- a/shapes/Edge.lua
+++ b/shapes/Edge.lua
@@ -1,37 +1,37 @@
 local Vec = _Require_relative(..., 'lib.DeWallua.vector-light',1)
 local VertexShape = _Require_relative(..., 'VertexShape')
 
----@class Edge : Shape
+---@class Edge : VertexShape
 local Edge = VertexShape:extend()
 Edge.name = 'edge'
 
 ---"Calculate" edge area
----@return number area
+---@return Edge self
 function Edge:calcArea()
 	self.area = 1
-	return self.area
+	return self
 end
 
 ---Calculate midpoint of edge
----@return Point centroid
+---@return Edge self
 function Edge:calcCentroid()
 	self.centroid.x = (self.vertices[1].x+self.vertices[2].x) / 2
 	self.centroid.y = (self.vertices[1].y+self.vertices[2].y) / 2
-	return self.centroid
+	return self
 end
 
----Calculate both area and centroid
----@return number area
----@return Point centroid
+---Calculate both area and centroidreturn Edge self
 function Edge:calcAreaCentroid()
-	return self:calcArea(), self:calcCentroid()
+	self:calcArea()
+	self:calcCentroid()
+	return self
 end
 
 ---Calculate radius of circumscribed circle
----@return number radius
+---@return Edge self
 function Edge:calcRadius()
 	self.radius = 0.5 * Vec.len(Vec.sub(self.vertices[1].x, self.vertices[1].y, self.vertices[2].x, self.vertices[2].y) )
-	return self.radius
+	return self
 end
 
 ---comment

--- a/shapes/Edge.lua
+++ b/shapes/Edge.lua
@@ -15,8 +15,10 @@ end
 ---Calculate midpoint of edge
 ---@return Edge self
 function Edge:calcCentroid()
-	self.centroid.x = (self.vertices[1].x+self.vertices[2].x) / 2
-	self.centroid.y = (self.vertices[1].y+self.vertices[2].y) / 2
+	local x1, y1 = self:getVertex(1)
+	local x2, y2 = self:getVertex(2)
+	self.centroid.x = (x1+x2) / 2
+	self.centroid.y = (y1+y2) / 2
 	return self
 end
 
@@ -30,7 +32,9 @@ end
 ---Calculate radius of circumscribed circle
 ---@return Edge self
 function Edge:calcRadius()
-	self.radius = 0.5 * Vec.len(Vec.sub(self.vertices[1].x, self.vertices[1].y, self.vertices[2].x, self.vertices[2].y) )
+	local x1, y1 = self:getVertex(1)
+	local x2, y2 = self:getVertex(2)
+	self.radius = 0.5 * Vec.len(Vec.sub(x1, y1, x2, y2) )
 	return self
 end
 
@@ -60,7 +64,9 @@ local function edge_iter(shape, i)
 	local v = shape.vertices
 	if i < #v then
 		local j = i < #v and i+1
-		return i, {v[i].x, v[i].y, v[j].x, v[j].y}
+		local ix, iy = shape:getVertex(i)
+		local jx, jy = shape:getVertex(j)
+		return i, {ix, iy, jx, jy}
 	end
 end
 
@@ -78,7 +84,9 @@ end
 ---@return number x2
 ---@return number y2
 function Edge:unpack()
-    return self.vertices[1].x, self.vertices[1].y, self.vertices[2].x, self.vertices[2].y
+	local x1, y1 = self:getVertex(1)
+	local x2, y2 = self:getVertex(2)
+    return x1, y1, x2, y2
 end
 
 if love and love.graphics then
@@ -86,7 +94,7 @@ if love and love.graphics then
 	function Edge:draw()
 		love.graphics.line(self:unpack())
 		love.graphics.setColor(0,1,1)
-		love.graphics.points(self.centroid.x, self.centroid.y)
+		love.graphics.points(self:getCentroid())
 		love.graphics.setColor(1,1,1)
 	end
 end

--- a/shapes/Edge.lua
+++ b/shapes/Edge.lua
@@ -17,8 +17,13 @@ end
 function Edge:calcCentroid()
 	local x1, y1 = self:getVertex(1)
 	local x2, y2 = self:getVertex(2)
-	self.centroid.x = (x1+x2) / 2
-	self.centroid.y = (y1+y2) / 2
+	local cx, cy = (x1+x2) / 2, (y1+y2) / 2
+
+	self:translateTo(cx,cy)
+
+	for i, v in ipairs(self.vertices) do
+		v.x, v.y = v.x - cx, v.y - cy
+	end
 	return self
 end
 

--- a/shapes/Ellipse.lua
+++ b/shapes/Ellipse.lua
@@ -16,43 +16,34 @@ Ellipse.name = 'ellipse'
 ---@param angle number radian offset
 function Ellipse:new(x, y, a, b, n, angle)
 	if not ( a or b ) then return false end -- We need both to make an ellipse!
-	-- Default to a ratio of major/minor axes = # of n per quadrant - multiply by 4 to get total n
-	local segs = n or max( floor(a/b)*4, 8)
-	-- Set ellipse coords
-	local x_offset 	= x or 0
-	local y_offset 	= y or 0
-	-- Set angle offset
+	x = x or 0
+	y = y or 0
 	angle = angle or 0
+	n = n or max(8, floor(a/b)*4) -- a/b = n per quadrant -> multiply by 4 to get total n
 
 	-- Init vertices list
 	local vertices = {}
 
 	-- Init delta-angle between vertices lying on ellipse hull
-	local d_rads = 2*pi / segs
+	local d_rads = 2*pi / n
 	-- For # of segs, compute vertex coordinates using
 	-- parametric eqns for an ellipse:
 	-- 		x = a * cos(theta)
 	-- 		y = b * sin(theta)
 	-- where a is the major axis and b is the minor axis
-	local a_offset = angle - d_rads
-	for i = 1, segs do
+	local a_offset = d_rads
+	for i = 1, n do
 		-- Increment our angle offset
 		a_offset = a_offset + d_rads
 		-- Add to vertices list
-		vertices[i] = {
-			x = x_offset + a * cos(a_offset),
-			y = y_offset + b * sin(a_offset)
-		}
+		table.insert(vertices, x + a * cos(a_offset))
+		table.insert(vertices, y + b * sin(a_offset))
 	end
-	-- Put everything into poly table and then return it
-    self.a, self.b  = a, b
-    self.n   		= n
-	self.vertices   = vertices			            -- list of {x,y} coords
-	self.convex     = true   					    -- boolean
-	self.centroid   = {x = x_offset, y = y_offset}	-- {x, y} coordinate pair
-	self.radius		= a							    -- radius of circumscribed circle
-	self.area		= pi*a*b						-- absolute/unsigned area of approx ellipse
-    self.angle      = angle
+
+	-- Set ellipse vars
+    self.a, self.b, self.n = a, b, n
+	Ellipse.super.new(self, vertices)
+	self:rotate(angle) -- set angle here because convex constructor defaults to 0
 end
 
 ---Return ctor args

--- a/shapes/Ellipse.lua
+++ b/shapes/Ellipse.lua
@@ -57,14 +57,4 @@ function Ellipse:unpack()
     return cx, cy, self.a, self.b, self.n
 end
 
-if love and love.graphics then
-	---Draw Ellipse w/ LOVE
-	---@param mode string fill/line
-	function Ellipse:draw(mode)
-		-- default fill to "line"
-		mode = mode or "line"
-		love.graphics.ellipse(mode, self:unpack())
-	end
-end
-
 return Ellipse

--- a/shapes/Ellipse.lua
+++ b/shapes/Ellipse.lua
@@ -53,7 +53,8 @@ end
 ---@return number b
 ---@return number n
 function Ellipse:unpack()
-    return self.centroid.x, self.centroid.y, self.a, self.b, self.n
+	local cx, cy = self:getCentroid()
+    return cx, cy, self.a, self.b, self.n
 end
 
 if love and love.graphics then

--- a/shapes/Rectangle.lua
+++ b/shapes/Rectangle.lua
@@ -1,8 +1,8 @@
 local Vec = _Require_relative(..., 'lib.DeWallua.vector-light',1)
-local Polygon = _Require_relative(..., 'ConvexPolygon')
+local ConvexPolygon = _Require_relative(..., 'ConvexPolygon')
 
 ---@class Rectangle : ConvexPolygon
-Rect = Polygon:extend()
+Rect = ConvexPolygon:extend()
 
 Rect.name = 'rect'
 

--- a/shapes/Rectangle.lua
+++ b/shapes/Rectangle.lua
@@ -34,7 +34,8 @@ end
 ---@return number dy
 ---@return number angle
 function Rect:unpack()
-	return self.centroid.x, self.centroid.y, self.dx, self.dy, self.angle
+	local cx, cy = self:getCentroid()
+	return cx, cy, self.dx, self.dy, self.angle
 end
 
 return Rect

--- a/shapes/Rectangle.lua
+++ b/shapes/Rectangle.lua
@@ -6,27 +6,24 @@ Rect = Polygon:extend()
 
 Rect.name = 'rect'
 
----Rect cotr
+---Rect ctor
 ---@param x number x position (center)
 ---@param y number y position (center)
 ---@param dx number width
----@param dy number height
----@param angle number radian offset
+---@param dy ?number height defaults to dx
+---@param angle ?number radian offset defaults to 0
 function Rect:new(x, y, dx, dy, angle)
-	if not ( dx and dy ) then return false end
-	local x_offset, y_offset = x or 0, y or 0
+	assert(dx, 'Rectangle constructor missing width/height')
+	dy = dy or dx
     self.dx, self.dy = dx, dy
 	self.angle = angle or 0
 	local hx, hy = dx/2, dy/2 -- halfsize
-	self.vertices = {
-		{x = x_offset - hx, y = y_offset - hy},
-		{x = x_offset + hx, y = y_offset - hy},
-		{x = x_offset + hx, y = y_offset + hy},
-		{x = x_offset - hx, y = y_offset + hy}
-	}
-	self.centroid  	= {x = x_offset, y = y_offset}
-	self.area 		= dx*dy
-	self.radius		= Vec.len(hx, hy)
+	Rect.super.new(self,
+		x - hx, y - hy,
+		x + hx, y - hy,
+		x + hx, y + hy,
+		x - hx, y + hy
+	)
 	self:rotate(self.angle)
 end
 

--- a/shapes/RegularPolygon.lua
+++ b/shapes/RegularPolygon.lua
@@ -49,7 +49,8 @@ end
 ---@return number radius
 ---@return number angle
 function RegularPolygon:unpack()
-    return self.centroid.x, self.centroid.y, self.n, self.radius, self.angle
+    local cx, cy = self:getCentroid()
+    return cx, cy, self.n, self.radius, self.angle
 end
 
 function RegularPolygon:_get_verts()

--- a/shapes/RegularPolygon.lua
+++ b/shapes/RegularPolygon.lua
@@ -1,9 +1,9 @@
-local Polygon = _Require_relative(..., 'ConvexPolygon')
+local ConvexPolygon = _Require_relative(..., 'ConvexPolygon')
 
 local pi, cos, sin, tan = math.pi, math.cos, math.sin, math.tan
 
 ---@class RegularPolygon : ConvexPolygon
-local RegularPolygon = Polygon:extend()
+local RegularPolygon = ConvexPolygon:extend()
 
 RegularPolygon.name = 'RegularPolygon'
 

--- a/shapes/RegularPolygon.lua
+++ b/shapes/RegularPolygon.lua
@@ -5,6 +5,8 @@ local pi, cos, sin, tan = math.pi, math.cos, math.sin, math.tan
 ---@class RegularPolygon : ConvexPolygon
 local RegularPolygon = Polygon:extend()
 
+RegularPolygon.name = 'RegularPolygon'
+
 ---Calculate area using regular area formula
 ---@return number area
 function RegularPolygon:calcArea()
@@ -22,25 +24,22 @@ end
 function RegularPolygon:new(x, y, n, radius, angle)
     -- Initialize our polygon's origin and rotation
     n = n or 3
-    self.angle = angle or 0
-    self.area = 0
-    -- Initalize our dummy point vars to put into the vertices list
-    local vertices = {}
+    angle = angle or 0
 
     -- Calculate the points
-    for i = n, 1, -1 do -- i = 1, n calculates vertices in clockwise order, so go backwards
-        local vx = ( sin( i / n * 2 * pi - self.angle) * radius) + x
-        local vy = ( cos( i / n * 2 * pi - self.angle) * radius) + y
-        vertices[#vertices+1] = {x = vx, y = vy}
+    local vertices = {}
+
+    for i = 1, n do
+        local vx = ( sin(-i / n * 2 * pi) * radius) + x
+        local vy = ( cos(-i / n * 2 * pi) * radius) + y
+        table.insert(vertices, vx)
+        table.insert(vertices, vy)
     end
 
     -- Set fields
     self.n, self.radius = n, radius
-    self.vertices 		= vertices     	    -- list of {x,y} coords
-    self.convex      	= true      		-- boolean
-    self.centroid       = {x = x, y = y}	-- {x, y} coordinate pair
-    -- Calculate the area of our polygon.
-    self:calcArea()
+    RegularPolygon.super.new(self, vertices)
+    self:rotate(angle)
 end
 
 ---Return ctor args

--- a/shapes/Shape.lua
+++ b/shapes/Shape.lua
@@ -1,17 +1,46 @@
 -- "Abstract" base object, provides some generic methods.
 local Object = Libs.classic
+local Transform = _Require_relative(..., 'classes.Transform', 1)
 
----@class Shape
----@field public centroid Point
+---@class Shape : Object
+---@field public transform Transform
 ---@field public area number
 ---@field public radius number
+---@field public vertices Point[]
 ---@field public parent nil|Shape|Collider
 local Shape = Object:extend()
 
+Shape.name = 'shape'
 Shape.type = 'shape'
+Shape.area = 0
+Shape.radius = 0
+Shape.vertices = {}
+Shape.parent = nil
+
+function Shape:new(transform)
+	self.transform = transform or Transform()
+end
+
+function Shape.fromComponents(x,y,ca,sa)
+	return Shape(
+		Transform(x,y,ca,sa)
+	)
+end
+
+---@return Transform
+function Shape:getTransform()
+	return self.transform
+end
+
+---@param transform Transform
+---@return Shape self
+function Shape:setTransform(transform)
+	self.transform = transform
+	return self
+end
 
 ---Get Shape's root container
----@return Collider | nil
+---@return Collider | Shape
 function Shape:getRoot()
 	local s = self
 	while s.parent do
@@ -22,22 +51,17 @@ end
 
 ---@return number area
 function Shape:getArea()
-    return self.area
+    return self.area * self.transform.s * self.transform.s
 end
 
 ---@return number x
 ---@return number y
 function Shape:getCentroid()
-    return self.centroid.x, self.centroid.y
-end
-
----@return number area, table centroid
-function Shape:getAreaCentroid()
-    return self.area, self.centroid
+    return self.transform:getTranslation()
 end
 
 function Shape:getRadius()
-	return self.radius
+	return self.radius * self.transform.s
 end
 
 function Shape:getBbox()
@@ -49,30 +73,60 @@ end
 function Shape:unpack()
 end
 
-function Shape:translate()
+---Rotate by specified radians
+---@param a number radians
+---@param x ?number reference x-coordinate to rotate about
+---@param y ?number reference y-coordinate to rotate about
+---@return Shape self
+function Shape:rotate(a,x,y)
+	self.transform:rotateA(a,x,y)
+	return self
+end
+
+---@param a number
+---@param x number x coordinate to rotate about
+---@param y number y coordinate to rotate about
+---@return Shape self
+function Shape:rotateTo(a, x, y)
+	self.transform:rotateToA(a, x, y)
+	return self
+end
+
+---Scale shape by a factor (multiplies previous factor)
+---@param sf number scale factor
+---@param sx ?number reference x-coordinate
+---@param sy ?number reference y-coordinate
+---@return Shape self
+function Shape:scale(sf, sx, sy)
+	self.transform:scale(sf, sx, sy)
+	return self
+end
+
+---Scale shape by a factor (sets factor)
+---@param sf number scale factor
+---@param sx ?number reference x-coordinate
+---@param sy ?number reference y-coordinate
+---@return Shape self
+function Shape:scaleTo(sf, sx, sy)
+	self.transform:scaleTo(sf, sx, sy)
+	return self
+end
+
+---Translate by displacement vector
+---@param x number
+---@param y number
+---@return Shape self
+function Shape:translate(x,y)
+	self.transform:translate(x,y)
+	return self
 end
 
 ---@param x number
 ---@param y number
 ---@return Shape self
 function Shape:translateTo(x, y)
-	local dx, dy = x - self.centroid.x, y - self.centroid.y
-	return self:translate(dx,dy)
-end
-
-function Shape:rotate()
-end
-
----@param angle_rads number
----@param ref_x number x coordinate to rotate about
----@param ref_y number y coordinate to rotate about
----@return Shape self
-function Shape:rotateTo(angle_rads, ref_x, ref_y)
-	local aoffset = angle_rads - self.angle
-	return self:rotate(aoffset, ref_x, ref_y)
-end
-
-function Shape:scale()
+	self.transform:translateTo(x, y)
+	return self
 end
 
 ---@param x number x coordinate to place copy at

--- a/shapes/Shape.lua
+++ b/shapes/Shape.lua
@@ -25,9 +25,10 @@ function Shape:getArea()
     return self.area
 end
 
----@return Point self.centroid
+---@return number x
+---@return number y
 function Shape:getCentroid()
-    return self.centroid
+    return self.centroid.x, self.centroid.y
 end
 
 ---@return number area, table centroid

--- a/shapes/Shape.lua
+++ b/shapes/Shape.lua
@@ -67,6 +67,13 @@ end
 function Shape:getBbox()
 end
 
+---Get vertex at index, except circles don't have any :p
+---@param i number
+---@return nil
+function Shape:getVertex(i)
+    return nil
+end
+
 function Shape:project()
 end
 

--- a/shapes/VertexShape.lua
+++ b/shapes/VertexShape.lua
@@ -1,0 +1,15 @@
+local Shape = _Require_relative(..., "Shape")
+
+local VertexShape = Shape:extend()
+
+---Get a vertex by its offset
+---@param i number
+---@return number|false v.x or false if beyond range
+---@return number|false v.y
+function VertexShape:getVertex(i)
+	if i > #self.vertices then return false, false end
+	local v = self.vertices[i]
+	return v.x, v.y
+end
+
+return VertexShape

--- a/shapes/VertexShape.lua
+++ b/shapes/VertexShape.lua
@@ -102,7 +102,6 @@ end
 ---@param y number
 function VertexShape:new(x,y, ...)
     VertexShape.super.new(self)
-	self.centroid = {x=0, y=0}
 	self.vertices = to_vertices(x,y, ...)
 	self.area = 0
 	self.radius = 0
@@ -152,69 +151,6 @@ function VertexShape:project(nx,ny)
 		if p < min_dot then min_dot = p elseif p > max_dot then max_dot = p end
 	end
 	return min_dot, max_dot
-end
-
----Translate by displacement vector
----@param dx number
----@param dy number
----@return VertexShape self
-function VertexShape:translate(dx, dy)
-	-- Translate each vertex by dx, dy
-	local vertices = self.vertices
-    for i = 1, #vertices do
-        vertices[i].x = vertices[i].x + dx
-        vertices[i].y = vertices[i].y + dy
-    end
-	-- Translate centroid
-	self.centroid.x = self.centroid.x + dx
-	self.centroid.y = self.centroid.y + dy
-    return self
-end
-
----Rotate by specified radians
----@param angle number radians
----@param refx number reference x-coordinate
----@param refy number reference y-coordinate
----@return VertexShape self
-function VertexShape:rotate(angle, refx, refy)
-	-- Default to centroid as ref-point
-    refx = refx or self.centroid.x
-	refy = refy or self.centroid.y
-	-- Rotate each vertex about ref-point
-    for i = 1, #self.vertices do
-        local v = self.vertices[i]
-        v.x, v.y = Vec.add(refx, refy, Vec.rotate(angle, v.x-refx, v.y - refy))
-    end
-	self.centroid.x, self.centroid.y = Vec.add(refx, refy, Vec.rotate(angle, self.centroid.x-refx, self.centroid.y-refy))
-	self.angle = self.angle + angle
-	return self
-end
-
---- scale helper function
-local function scale_p(x,y, sf,rx,ry)
-	return Vec.add(rx, ry, Vec.mul(sf, x-rx, y - ry))
-end
-
----Scale polygon
----@param sf number scale factor
----@param refx number reference x-coordinate
----@param refy number reference y-coordinate
----@return VertexShape self
-function VertexShape:scale(sf, refx, refy)
-	-- Default to centroid as ref-point
-	local c = self.centroid
-    refx = refx or c.x
-	refy = refy or c.y
-	-- Push each vertex out from the ref point by scale-factor
-    for i = 1, #self.vertices do
-        local v = self.vertices[i]
-        v.x, v.y = scale_p(v.x,v.y, sf,refx,refy)
-    end
-	c.x, c.y = scale_p(c.x, c.y, sf, refx, refy)
-    -- Recalculate area, and radius
-    self.area = self.area * sf * sf
-    self.radius = self.radius * sf
-	return self
 end
 
 local function iter_edges(shape, i)

--- a/shapes/VertexShape.lua
+++ b/shapes/VertexShape.lua
@@ -77,7 +77,7 @@ function VertexShape:calcAreaCentroid()
 		cx / (6*self.area),
 		cy / (6*self.area)
 	)
-	print('calc centroid: '..(cx/(6*self.area))..', '..(cy/(6*self.area)))
+
 	-- Center the shape on the origin
 	center_shape(self)
 	return self
@@ -120,10 +120,10 @@ function VertexShape:getVertex(i)
 end
 
 ---Get an edge by index
----@param i number
----@return table|false res edge of form {x1,y1, x2,y2} or false if index out of range
+---@param i number index
+---@return table|nil edge of form {x1,y1, x2,y2} or nil if index out of range
 function VertexShape:getEdge(i)
-	if i > #self.vertices then return false end
+	if i > #self.vertices or i < 1 then return nil end
 	local verts = self.vertices
 	local j = i < #verts and i+1 or 1
 	local p1x, p1y = self:getVertex(i)

--- a/shapes/VertexShape.lua
+++ b/shapes/VertexShape.lua
@@ -2,6 +2,27 @@ local Shape = _Require_relative(..., "Shape")
 
 local VertexShape = Shape:extend()
 
+-- Recursive function that returns a list of {x=#,y=#} coordinates given a list of procedural, ccw coordinate pairs
+local function to_verts(vertices, x, y, ...)
+    if not (x and y) then return vertices end
+	vertices[#vertices + 1] = {x = x, y = y} -- , dx = 0, dy = 0}   -- set vertex
+	return to_verts(vertices, ...)
+end
+
+local function to_vertices(x, ...)
+	return type(x) == 'table'and to_verts({}, unpack(x)) or to_verts({}, x,...)
+end
+
+-- Create new Polygon object
+---@vararg number x,y tuples
+---@param x number
+---@param y number
+function VertexShape:new(x,y, ...)
+    VertexShape.super.new(self)
+	self.centroid = {x=0, y=0}
+	self.vertices = to_vertices(x,y, ...)
+end
+
 ---Get a vertex by its offset
 ---@param i number
 ---@return number|false v.x or false if beyond range

--- a/shapes/VertexShape.lua
+++ b/shapes/VertexShape.lua
@@ -1,5 +1,11 @@
 local Shape = _Require_relative(..., "Shape")
+local Vec = _Require_relative(..., 'lib.DeWallua.vector-light',1)
+local abs = math.abs
+local push = table.insert
 
+---@class VertexShape : Shape
+---@field private centroid table<string, number>
+---@field private vertices table<number, table<string, number>>
 local VertexShape = Shape:extend()
 
 -- Recursive function that returns a list of {x=#,y=#} coordinates given a list of procedural, ccw coordinate pairs
@@ -31,6 +37,223 @@ function VertexShape:getVertex(i)
 	if i > #self.vertices then return false, false end
 	local v = self.vertices[i]
 	return v.x, v.y
+end
+
+---Get an edge by index
+---@param i number
+---@return table|false res edge of form {x1,y1, x2,y2} or false if index out of range
+function VertexShape:getEdge(i)
+	if i > #self.vertices then return false end
+	local verts = self.vertices
+	local j = i < #verts and i+1 or 1
+	local p1x, p1y = self:getVertex(i)
+	local p2x, p2y = self:getVertex(j)
+	return {p1x, p1y, p2x, p2y}
+end
+
+---Project polygon along normalized vector
+---@param nx number normalized x-component
+---@param ny number normalized y-component
+---@return number minimum, number maximumum smallest, largest projection
+function VertexShape:project(nx,ny)
+	local vertices = self.vertices
+	local proj_x, proj_y
+	local p, min_dot, max_dot
+	-- Project each point onto vector <nx, ny>
+	proj_x, proj_y = self:getVertex(1)
+	-- Init our min/max dot products (Can't init to random value)
+	min_dot = Vec.dot(proj_x,proj_y, nx,ny)
+	max_dot = min_dot
+	-- Create new projection vectors, dot-prod them with the input vector, and return the min/max
+	for i = 2, #vertices do
+		proj_x, proj_y = self:getVertex(i)
+		p = Vec.dot(proj_x,proj_y, nx,ny)
+		if p < min_dot then min_dot = p elseif p > max_dot then max_dot = p end
+	end
+	return min_dot, max_dot
+end
+
+---Translate by displacement vector
+---@param dx number
+---@param dy number
+---@return VertexShape self
+function VertexShape:translate(dx, dy)
+	-- Translate each vertex by dx, dy
+	local vertices = self.vertices
+    for i = 1, #vertices do
+        vertices[i].x = vertices[i].x + dx
+        vertices[i].y = vertices[i].y + dy
+    end
+	-- Translate centroid
+	self.centroid.x = self.centroid.x + dx
+	self.centroid.y = self.centroid.y + dy
+    return self
+end
+
+---Rotate by specified radians
+---@param angle number radians
+---@param refx number reference x-coordinate
+---@param refy number reference y-coordinate
+---@return VertexShape self
+function VertexShape:rotate(angle, refx, refy)
+	-- Default to centroid as ref-point
+    refx = refx or self.centroid.x
+	refy = refy or self.centroid.y
+	-- Rotate each vertex about ref-point
+    for i = 1, #self.vertices do
+        local v = self.vertices[i]
+        v.x, v.y = Vec.add(refx, refy, Vec.rotate(angle, v.x-refx, v.y - refy))
+    end
+	self.centroid.x, self.centroid.y = Vec.add(refx, refy, Vec.rotate(angle, self.centroid.x-refx, self.centroid.y-refy))
+	self.angle = self.angle + angle
+	return self
+end
+
+--- scale helper function
+local function scale_p(x,y, sf,rx,ry)
+	return Vec.add(rx, ry, Vec.mul(sf, x-rx, y - ry))
+end
+
+---Scale polygon
+---@param sf number scale factor
+---@param refx number reference x-coordinate
+---@param refy number reference y-coordinate
+---@return VertexShape self
+function VertexShape:scale(sf, refx, refy)
+	-- Default to centroid as ref-point
+	local c = self.centroid
+    refx = refx or c.x
+	refy = refy or c.y
+	-- Push each vertex out from the ref point by scale-factor
+    for i = 1, #self.vertices do
+        local v = self.vertices[i]
+        v.x, v.y = scale_p(v.x,v.y, sf,refx,refy)
+    end
+	c.x, c.y = scale_p(c.x, c.y, sf, refx, refy)
+    -- Recalculate area, and radius
+    self.area = self.area * sf * sf
+    self.radius = self.radius * sf
+	return self
+end
+
+local function iter_edges(shape, i)
+	i = i + 1
+	local len, ix, iy = #shape.vertices, shape:getVertex(i)
+	if i <= len then
+		local j = i < len and i+1 or 1
+		local jx, jy = shape:getVertex(j)
+		return i, {ix, iy, jx, jy}
+	end
+end
+
+---Edge Iterator
+---@return function
+---@return VertexShape
+---@return number
+function VertexShape:ipairs()
+    return iter_edges, self, 0
+end
+
+---Iterate through vectors that make up edges
+---@param shape VertexShape
+---@param i number
+---@return integer
+---@return table
+local function iter_vecs(shape, i)
+	i = i + 1
+	local len, ix, iy = #shape.vertices, shape:getVertex(i)
+	if i <= len then
+		local j = i < len and i+1 or 1
+		local jx, jy = shape:getVertex(j)
+		return i, {x = jx - ix, y = jy - iy}
+	end
+end
+
+---Iterate over edge vectors
+---@return function
+---@return VertexShape
+---@return number
+function VertexShape:vecs()
+    return iter_vecs, self, 0
+end
+
+---Project each individual edge instead of using self:project like in Circle
+---@param x number ray origin
+---@param y number ray origin
+---@param dx number normalized x component
+---@param dy number normalized y component
+---@return boolean hit
+function VertexShape:rayIntersects(x,y, dx,dy)
+	dx, dy = Vec.perpendicular(dx,dy)
+    local d = Vec.dot(x,y, dx,dy)
+	for i, edge in self:ipairs() do
+		local e1 = Vec.dot(edge[1],edge[2], dx,dy)
+		local e2 = Vec.dot(edge[3],edge[4], dx,dy)
+		if (e1-d) * (e2-d) <= 0 then return true end
+	end
+	return false
+end
+
+-- https://stackoverflow.com/a/32146853/12135804
+---Return all intersections as distances along ray
+---@param x number ray origin
+---@param y number ray origin
+---@param dx number normalized x component
+---@param dy number normalized y component
+---@param ts table
+---@return table | nil intersections
+function VertexShape:rayIntersections(x,y, dx,dy, ts)
+	local v1x, v1y, v2x, v2y
+	local nx, ny = -dy, dx
+	ts = ts or {}
+	for i, edge in self:ipairs() do
+		v1x, v1y = Vec.sub(x, y, edge[1], edge[2])
+		v2x, v2y = Vec.sub(edge[3], edge[4], edge[1], edge[2])
+		local dot = Vec.dot(v2x, v2y, nx, ny)
+		if abs(dot) < 0.0001 then break end
+		local t1 = Vec.det(v2x,v2y, v1x,v1y) / dot
+		local t2 = Vec.dot(v1x,v1y, nx,ny) / dot
+		if t1 >= 0 and (t2 >= 0 and t2 <= 1) then push(ts, t1) end
+	end
+	return #ts > 0 and ts or nil
+end
+
+---Contact Functions
+function VertexShape:getSupport(nx,ny)
+    local maxd, index = -math.huge , 1
+    for i = 1, #self.vertices do
+		local px,py = self:getVertex(i)
+        local projection = Vec.dot(px,py, nx,ny)
+        if projection > maxd then
+            maxd = projection
+            index = i
+        end
+    end
+    return index
+end
+
+---Get the edge involved in a collision
+---@param nx number normalized x dir
+---@param ny number normalized y dir
+---@return table Max-Point
+---@return table Edge
+function VertexShape:getFeature(nx,ny)
+    local verts = self.vertices
+    -- get farthest point in direction of normal
+    local index = self:getSupport(nx,ny)
+    -- test adjacent points to find edge most perpendicular to normal
+    local vx, vy = self:getVertex(index)
+    local i0 = index - 1 >= 1 and index - 1 or #verts
+    local i1 = index + 1 <= #verts and index + 1 or 1
+    local v0x, v0y = self:getVertex(i0)
+    local v1x, v1y = self:getVertex(i1)
+    local gx,gy = Vec.normalize( Vec.sub(vx,vy, v0x,v0y) )
+    local hx,hy = Vec.normalize( Vec.sub(vx,vy, v1x,v1y) )
+    if math.abs(Vec.dot(gx,gy, nx,ny)) <= math.abs(Vec.dot(hx,hy, nx,ny)) then
+        return {x=vx,y=vy}, {{x=v0x,y=v0y}, {x=vx,y=vy}}
+    else
+        return {x=vx,y=vy}, {{x=vx,y=vy}, {x=v1x,y=v1y}}
+    end
 end
 
 return VertexShape

--- a/shapes/VertexShape.lua
+++ b/shapes/VertexShape.lua
@@ -111,10 +111,10 @@ end
 
 ---Get a vertex by its offset
 ---@param i number
----@return number|false v.x or false if beyond range
----@return number|false v.y
+---@return number|nil v.x or nil if beyond range
+---@return number|nil v.y
 function VertexShape:getVertex(i)
-	if i > #self.vertices then return false, false end
+	if i > #self.vertices then return nil, nil end
 	local v = self.vertices[i]
 	return self.transform:transform(v.x, v.y)
 end

--- a/shapes/VertexShape.lua
+++ b/shapes/VertexShape.lua
@@ -116,7 +116,7 @@ end
 function VertexShape:getVertex(i)
 	if i > #self.vertices then return false, false end
 	local v = self.vertices[i]
-	return v.x, v.y
+	return self.transform:transform(v.x, v.y)
 end
 
 ---Get an edge by index

--- a/shapes/VertexShape.lua
+++ b/shapes/VertexShape.lua
@@ -77,6 +77,7 @@ function VertexShape:calcAreaCentroid()
 		cx / (6*self.area),
 		cy / (6*self.area)
 	)
+	print('calc centroid: '..(cx/(6*self.area))..', '..(cy/(6*self.area)))
 	-- Center the shape on the origin
 	center_shape(self)
 	return self


### PR DESCRIPTION
Main goal of this feature is to optimize the transformation functions (rotate, scale, translate) by introducing a `Transform` object and corresponding property on the base `Shape` class.
Things that have been done as a result of this change:
1. Half of the `ConvexPolygon` class was split out into a separate `VertexShape` class that is responsible for working with, you guessed it, vertices. Both `Edge` and `ConvexPolygon` extend from this class
2. All the extending shapes call their super constructors. This is so that the `Shape.transform` property can be initialized w/o having to touch it anywhere else.
3. Introduced a `getVertex` method to grab transformed points. Moreover, `getCentroid`, and anything else that touches vertices now internally transforms them and returns two scalar values. 

This PR does not add a transform property to the `Collider` class. Mainly because that might require a way of efficiently stacking transforms, and that's not super necessary at the moment.