### PR TITLE
Add `getVertices` method to VertexShape

### DIFF
--- a/shapes/VertexShape.lua
+++ b/shapes/VertexShape.lua
@@ -119,6 +119,20 @@ function VertexShape:getVertex(i)
 	return self.transform:transform(v.x, v.y)
 end
 
+---Get list of vertices
+---@return {x: number, y: number}
+function VertexShape:getVertices()
+	local verts = {}
+
+	for i = 1, #self.vertices do
+		local x, y = self:getVertex(i)
+		local v = {x = x, y = y}
+		table.insert(verts, v)
+	end
+
+	return verts
+end
+
 ---Get an edge by index
 ---@param i number index
 ---@return table|nil edge of form {x1,y1, x2,y2} or nil if index out of range


### PR DESCRIPTION
Closes #30

Returns transformed vertices as a list of tables with x/y keys containing the x/y values

Did not add an empty method to the Shape class because all references to vertices in there should be removed.